### PR TITLE
Reimplement as more structured and modular

### DIFF
--- a/src/main/java/fxlauncher/config/LauncherOption.java
+++ b/src/main/java/fxlauncher/config/LauncherOption.java
@@ -19,7 +19,6 @@ import fxlauncher.model.lifecycle.LifecyclePhase;
 
 /**
  * The set of configurable options for FxLauncher.
- * 
  * @author idavis1
  */
 public enum LauncherOption {

--- a/src/main/java/fxlauncher/config/LauncherOption.java
+++ b/src/main/java/fxlauncher/config/LauncherOption.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ public enum LauncherOption {
 	HEADLESS("headless", false, Defaults.BOOL_FALSE, null, null),
 	WHATS_NEW_URL("whats-new-url", true, Defaults.NONE, null, Validator.URL),
 	LINGERING_UPDATE_SCREEN("lingering-update-screen", true, Defaults.BOOL_TRUE, null, Validator.BOOL),;
-
+	
 	// the string that should be used in a command-line argument or properties file to set this option
 	private final String label;
 	private final Pattern pattern;

--- a/src/main/java/fxlauncher/config/LauncherOption.java
+++ b/src/main/java/fxlauncher/config/LauncherOption.java
@@ -1,0 +1,207 @@
+package fxlauncher.config;
+
+import static fxlauncher.model.lifecycle.LifecyclePhase.LOAD_EMBEDDED_CONFIG;
+import static fxlauncher.model.lifecycle.LifecyclePhase.PARSE_CLI_ARGS;
+import static fxlauncher.model.lifecycle.LifecyclePhase.STARTUP;
+import static java.util.stream.Collectors.joining;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import fxlauncher.model.lifecycle.LifecyclePhase;
+
+/**
+ * The set of configurable options for FxLauncher.
+ * 
+ * @author idavis1
+ */
+public enum LauncherOption {
+	CONFIG_FILE("config-file", true, Defaults.CONFIG_FILE, null, null),
+	OVERRIDES_URL("overrides-url", true, Defaults.NONE, null, Validator.URL),
+	MANIFEST_URL("manifest-url", true, Defaults.NONE, null, Validator.URL),
+	MANIFEST_FILE("manifest-file", true, Defaults.MANIFEST_FILE, null, null),
+	ARTIFACTS_REPO_URL("artifacts-repo-url", true, Defaults.NONE, null, Validator.URL),
+	CACHE_DIR("cache-dir", true, Defaults.CACHE_DIR, Resolver.CACHE_DIR, null),
+	LOG_FILE("log-file", true, Defaults.LOG_FILE, null, null),
+	IGNORE_SSL("ignore-ssl", true, Defaults.BOOL_FALSE, null, Validator.BOOL),
+	OFFLINE("offline", false, Defaults.BOOL_FALSE, null, null),
+	STOP_ON_UPDATE_ERROR("stop-on-update-error", false, Defaults.BOOL_TRUE, null, null),
+	ACCEPT_DOWNGRADE("accept-downgrade", false, Defaults.BOOL_FALSE, null, null),
+	PRELOAD_NATIVE_LIBS("preload-native-libs", true, Defaults.NONE, null, null),
+	HEADLESS("headless", false, Defaults.BOOL_FALSE, null, null),
+	WHATS_NEW_URL("whats-new-url", true, Defaults.NONE, null, Validator.URL),
+	LINGERING_UPDATE_SCREEN("lingering-update-screen", true, Defaults.BOOL_TRUE, null, Validator.BOOL),;
+
+	// the string that should be used in a command-line argument or properties file to set this option
+	private final String label;
+	private final Pattern pattern;
+
+	// used to identify when a value has not been explicitly set by a user
+	private LifecyclePhase lastSetDuring = STARTUP;
+
+	private final String defaultVal;
+
+	private final Resolver resolver;
+	private final Validator validator;
+
+	/**
+	 * Retrieve the set of labels for all {@link LauncherOption} instances
+	 * @return the set of labels
+	 */
+	public static Set<String> labels() {
+		return Arrays.asList(values()).stream().map(LauncherOption::getLabel).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Get a subset of options that satisfy some predicate
+	 * @param predicate The predicate that determines which enum instances should be included in the subset
+	 * @return the set of {@link LauncherOption} objects that satisfy the predicate (return true);
+	 */
+	private static Set<LauncherOption> getSubset(Predicate<LauncherOption> predicate) {
+		return Stream.of(values()).filter(predicate)
+				.collect(Collectors.toCollection(() -> EnumSet.noneOf(LauncherOption.class)));
+	}
+
+	/**
+	 * Get all those options that were most recently set from a properties file
+	 * @return the set of {@link LauncherOption} objects
+	 */
+	public static Set<LauncherOption> getProps() {
+		return getSubset(LauncherOption::isProp);
+	}
+
+	/**
+	 * Get all those options that were most recently set from a command-line argument
+	 * @return the set of {@link LauncherOption} objects
+	 */
+	public static Set<LauncherOption> getArgs() {
+		return getSubset(LauncherOption::isArg);
+	}
+
+	/**
+	 * Get all those options that have not been explicitly set
+	 * @return the set of {@link LauncherOption} objects;
+	 */
+	public static Set<LauncherOption> getUnset() {
+		return getSubset(LauncherOption::isUnset);
+	}
+
+	private LauncherOption(String label, boolean hasArg, String defaultVal, Resolver resolver, Validator validator) {
+		this.label = label;
+		this.defaultVal = defaultVal;
+
+		String patternString = Stream.of("--", label, hasArg ? "(=(.+)" : "").collect(joining());
+		pattern = Pattern.compile(patternString);
+
+		this.resolver = resolver == null ? Resolver.DEFAULT : resolver;
+		this.validator = validator == null ? Validator.DEFAULT : validator;
+	}
+
+	/**
+	 * get the label from this {@link LauncherOption} instance
+	 * @return the label for a particular {@link LauncherOption}
+	 */
+	public String getLabel() {
+		return this.label;
+	}
+
+	/**
+	 * get the default value from this {@link LauncherOption}
+	 * @return the default value for a particular {@link LauncherOption}
+	 */
+	public String getDefault() {
+		return this.defaultVal;
+	}
+
+	/**
+	 * check whether this @{link LauncherOption} was last set from a properties file
+	 * @return {@code true} if this {@link LauncherOption} was last set from a properties file, {@code false} otherwise
+	 */
+	public boolean isProp() {
+		return lastSetDuring == LOAD_EMBEDDED_CONFIG;
+	}
+
+	/**
+	 * check whether this {@link LauncherOption} was last set from a command-line argument
+	 * @return {@code true} if this {@link LauncherOption} was last set from a command-line argument, {@code false} otherwise
+	 */
+	public boolean isArg() {
+		return lastSetDuring == PARSE_CLI_ARGS;
+	}
+
+	/**
+	 * check whether this {@link LauncherOption} has been explicitly set
+	 * @return {@code true} if this {@link LauncherOption} has ever been explicitly set, {@code false} otherwise
+	 */
+	public boolean isSet() {
+		return lastSetDuring != STARTUP;
+	}
+
+	/**
+	 * check whether this {@link LauncherOption}  has not been explicitly set
+	 * @return {@code false} if this {@link LauncherOption} has ever been explicitly set, {@code true} otherwise
+	 */
+	public boolean isUnset() {
+		return !this.isSet();
+	}
+
+	/**
+	 * get a Matcher object that can be used to match a String to a {@link LauncherOption}
+	 * used to resolve properties and command-line arguments
+	 * @param arg
+	 * @return a {@link Matcher} created from the {@link LauncherOption}'s label and the string to be matched.
+	 */
+	Matcher getMatcher(String arg) {
+		return pattern.matcher(arg);
+	}
+
+	/**
+	 * get the {@link Resolver} registered to a {@link LauncherOption}
+	 * @return the {@link Resolver}
+	 */
+	Resolver getResolver() {
+		return resolver;
+	}
+
+	/**
+	 * get the {@link Validator} registered to a {@link LauncherOption}
+	 * @return
+	 */
+	Validator getValidator() {
+		return validator;
+	}
+
+	/**
+	 * make a note of the most recent time this {@link LauncherOption} was set
+	 * @param phase
+	 */
+	void recordOptionSet(LifecyclePhase phase) {
+		this.lastSetDuring = phase;
+	}
+
+	/**
+	 * The set of default values for FxLauncher {@link LauncherOption} objects
+	 *
+	 * @implNote these are included in an inner class rather than as standard
+	 * 'private static final String' constants because Java does not provide
+	 * access to static objects during execution of the enum constructors.
+	 * 
+	 * @author idavis1
+	 */
+	private static class Defaults {
+		private static final String CONFIG_FILE = "launcher.properties";
+		private static final String LOG_FILE = System.getProperty("java.io.tmpdir") + "fxlauncher.log";
+		private static final String MANIFEST_FILE = "app.xml";
+		private static final String CACHE_DIR = Paths.get(".").toString();
+		private static final String BOOL_FALSE = Boolean.FALSE.toString();
+		private static final String BOOL_TRUE = Boolean.TRUE.toString();
+		private static final String NONE = null;
+	}
+}

--- a/src/main/java/fxlauncher/config/Resolver.java
+++ b/src/main/java/fxlauncher/config/Resolver.java
@@ -1,16 +1,31 @@
 package fxlauncher.config;
 
 import java.util.function.UnaryOperator;
+import java.util.logging.Logger;
 
 import fxlauncher.model.GenericPathLabel;
 import fxlauncher.model.OS;
 
+@FunctionalInterface
+/**
+ * Resolver performs a transformation on a String
+ * 
+ * example: {@link LauncherOption} instance {@link CACHE_DIR} can accept
+ * two sentinel values, ALLUSERS and USERLIB, which should be resolved to
+ * OS-specific appropriate paths when accessed
+ * 
+ * @author idavis1
+ */
 public interface Resolver extends UnaryOperator<String>{
+	
+	static final Logger log = Logger.getLogger(Resolver.class.getName());
 
 	public static Resolver DEFAULT = unresolved -> unresolved;
 	
 	public static final Resolver CACHE_DIR = unresolved -> {
 		if(unresolved == null) return unresolved;
+		log.finer("Attempting resolution of CACHE_DIR");
+		log.finer(String.format("Unresolved value: '%s'", unresolved));
 		String resolved = unresolved; // assume no change, then check if change is necessary
 
 		for(GenericPathLabel genericPath : GenericPathLabel.values()) {
@@ -20,6 +35,7 @@ public interface Resolver extends UnaryOperator<String>{
 			}
 		}
 		
+		log.finer(String.format("Returning resolved value of CACHE_DIR: '%s'", unresolved));
 		return resolved;	
 	};
 }

--- a/src/main/java/fxlauncher/config/Resolver.java
+++ b/src/main/java/fxlauncher/config/Resolver.java
@@ -1,0 +1,25 @@
+package fxlauncher.config;
+
+import java.util.function.Function;
+
+import fxlauncher.model.GenericPathLabel;
+import fxlauncher.model.OS;
+
+public interface Resolver extends Function<String, String>{
+
+	public static Resolver DEFAULT = string -> string;
+	
+	public static final Resolver CACHE_DIR = unresolved -> {
+		if(unresolved == null) return unresolved;
+		String resolved = unresolved; // assume no change, then check if change is necessary
+
+		for(GenericPathLabel genericPath : GenericPathLabel.values()) {
+			if(unresolved.startsWith(genericPath.name())) {
+				String trimmed = unresolved.replace(genericPath.name() + "/", "");
+				resolved = OS.current.getGenericPath(genericPath).resolve(trimmed).toString();
+			}
+		}
+		
+		return resolved;	
+	};
+}

--- a/src/main/java/fxlauncher/config/Resolver.java
+++ b/src/main/java/fxlauncher/config/Resolver.java
@@ -1,13 +1,13 @@
 package fxlauncher.config;
 
-import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import fxlauncher.model.GenericPathLabel;
 import fxlauncher.model.OS;
 
-public interface Resolver extends Function<String, String>{
+public interface Resolver extends UnaryOperator<String>{
 
-	public static Resolver DEFAULT = string -> string;
+	public static Resolver DEFAULT = unresolved -> unresolved;
 	
 	public static final Resolver CACHE_DIR = unresolved -> {
 		if(unresolved == null) return unresolved;

--- a/src/main/java/fxlauncher/config/Validator.java
+++ b/src/main/java/fxlauncher/config/Validator.java
@@ -1,0 +1,30 @@
+package fxlauncher.config;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+/*
+ * Functional Interface for validating values passed to LauncherConfig
+ * plus default implementations for common cases.
+ */
+public interface Validator extends Predicate<String>{
+
+	// OWASP-supplied URL pattern-matching regexp
+	static final String URL_REGEX =
+            "^((((https?|ftps?|gopher|telnet|nntp)://)|(mailto:|news:))" +
+            "(%[0-9A-Fa-f]{2}|[-()_.!~*';/?:@&=+$,A-Za-z0-9])+)" +
+            "([).!';/?:,][[:blank:]])?$";
+ 
+    static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
+
+	
+	public static final Validator DEFAULT = string -> true;
+	
+	public static final Validator BOOL = string -> {
+		boolean isBool = (string != null);
+		isBool &= string.equalsIgnoreCase("false") || string.equalsIgnoreCase("false");
+		return isBool;
+	};
+	
+	public static final Validator URL = string -> URL_PATTERN.matcher(string).matches();
+}

--- a/src/main/java/fxlauncher/config/Validator.java
+++ b/src/main/java/fxlauncher/config/Validator.java
@@ -1,13 +1,19 @@
 package fxlauncher.config;
 
+import static java.util.logging.Logger.getLogger;
+
 import java.util.function.Predicate;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
+@FunctionalInterface
 /*
  * Functional Interface for validating values passed to LauncherConfig
  * plus default implementations for common cases.
  */
 public interface Validator extends Predicate<String>{
+	
+	static final Logger log = getLogger(Validator.class.getName());
 
 	// OWASP-supplied URL pattern-matching regexp
 	static final String URL_REGEX =
@@ -21,10 +27,16 @@ public interface Validator extends Predicate<String>{
 	public static final Validator DEFAULT = string -> true;
 	
 	public static final Validator BOOL = string -> {
+		log.finer(String.format("validating as boolean: '%s'", string));
+
 		boolean isBool = (string != null);
 		isBool &= string.equalsIgnoreCase("false") || string.equalsIgnoreCase("false");
 		return isBool;
 	};
 	
-	public static final Validator URL = string -> URL_PATTERN.matcher(string).matches();
+	public static final Validator URL = string -> {
+		log.finer(String.format("validating as URL: '%s'", string));
+
+		return URL_PATTERN.matcher(string).matches();
+	};
 }

--- a/src/main/java/fxlauncher/except/FxLauncherException.java
+++ b/src/main/java/fxlauncher/except/FxLauncherException.java
@@ -1,0 +1,31 @@
+package fxlauncher.except;
+
+/**
+ * Abstract RuntimeException that should be the root of all RuntimeExceptions
+ * that are thrown during execution of FxLauncher.
+ * @author idavis1
+ */
+public abstract class FxLauncherException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
+	public FxLauncherException() {
+		super();
+	}
+
+	public FxLauncherException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public FxLauncherException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public FxLauncherException(String message) {
+		super(message);
+	}
+
+	public FxLauncherException(Throwable cause) {
+		super(cause);
+	}
+	
+}

--- a/src/main/java/fxlauncher/except/FxLauncherValidationException.java
+++ b/src/main/java/fxlauncher/except/FxLauncherValidationException.java
@@ -1,0 +1,33 @@
+package fxlauncher.except;
+
+/**
+ * Unchecked exception. Implementation handles the specific case where some configurable
+ * parameter was passed a value that did not validate
+ */
+public class FxLauncherValidationException extends FxLauncherException {
+
+	private static final long serialVersionUID = 1L;
+
+	public FxLauncherValidationException() {
+		super();
+	}
+
+	public FxLauncherValidationException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public FxLauncherValidationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public FxLauncherValidationException(String message) {
+		super(message);
+	}
+
+	public FxLauncherValidationException(Throwable cause) {
+		super(cause);
+	}
+
+	
+}

--- a/src/main/java/fxlauncher/model/GenericPathLabel.java
+++ b/src/main/java/fxlauncher/model/GenericPathLabel.java
@@ -1,0 +1,14 @@
+package fxlauncher.model;
+
+/**
+ * Sentinel values that can be embedded in {@link LauncherConfig}
+ * entries representing paths. Adding a suitable {@link Resolver}
+ * should replace the string-equivalents of these values with the
+ * appropriate Operating-System-specific paths.
+ * 
+ * @author idavis1
+ */
+public enum GenericPathLabel {
+	USERLIB,
+	ALLUSERS,
+}

--- a/src/main/java/fxlauncher/model/OS.java
+++ b/src/main/java/fxlauncher/model/OS.java
@@ -2,11 +2,14 @@ package fxlauncher.model;
 
 import static fxlauncher.model.GenericPathLabel.ALLUSERS;
 import static fxlauncher.model.GenericPathLabel.USERLIB;
+import static java.util.logging.Logger.getLogger;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.logging.Logger;
+
 
 /**
  * Represents an operating-system supported by FxLauncher
@@ -21,6 +24,7 @@ public enum OS {
 	OTHER,
 	;
 	
+	private final static Logger log = getLogger(OS.class.getName());
 	public static final OS current;
 	
 	private final Path home = Paths.get(System.getProperty("user.home"));
@@ -57,6 +61,7 @@ public enum OS {
 		return pathMap.get(label);
 	}
 	
+	// initializer runs at class-load time
 	static {
 		String os = System.getProperty("os.name", "generic").toLowerCase();
 		
@@ -64,5 +69,6 @@ public enum OS {
 		else if (os.contains("win")) current = WIN;
 		else if (os.contains("nux")) current = LINUX;
 		else current = OTHER;
+		log.finer(String.format("Current operating system is: %s", MAC));
 	}
 }

--- a/src/main/java/fxlauncher/model/OS.java
+++ b/src/main/java/fxlauncher/model/OS.java
@@ -1,0 +1,68 @@
+package fxlauncher.model;
+
+import static fxlauncher.model.GenericPathLabel.ALLUSERS;
+import static fxlauncher.model.GenericPathLabel.USERLIB;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Represents an operating-system supported by FxLauncher
+ * Also provides resolution of OS-specific generic paths USERLIB and ALLUSERS
+ * @author idavis1
+ *
+ */
+public enum OS {
+	WIN,
+	MAC,
+	LINUX,
+	OTHER,
+	;
+	
+	public static final OS current;
+	
+	private final Path home = Paths.get(System.getProperty("user.home"));
+	private final Map<GenericPathLabel, Path> pathMap = new EnumMap<GenericPathLabel, Path>(GenericPathLabel.class);
+	
+	private OS() {
+		Path userLibPath;
+		Path allUsersPath;
+		
+		switch (this.name().toLowerCase()) {
+			case "mac":
+				userLibPath = home.resolve("Library").resolve("Application Support");
+				allUsersPath = Paths.get("/Library/Application Support");
+				break;
+			case "win":
+				userLibPath = home.resolve("AppData").resolve("Local");
+				allUsersPath = Paths.get(System.getenv("ALLUSERSPROFILE"));
+				break;
+			default:
+				userLibPath = home;
+				allUsersPath = Paths.get("/usr/local/share");
+				break;
+		}
+		pathMap.put(USERLIB, userLibPath);
+		pathMap.put(ALLUSERS, allUsersPath);
+	}
+	
+	/**
+	 * Fetch the generic path for a supported sentinel value and the OS represented by this instance
+	 * @param label the sentinel value, as an enum
+	 * @return the {@link Path} object for the provided sentinel value.
+	 */
+	public Path getGenericPath(GenericPathLabel label) {
+		return pathMap.get(label);
+	}
+	
+	static {
+		String os = System.getProperty("os.name", "generic").toLowerCase();
+		
+		if ((os.contains("mac")) || (os.contains("darwin"))) current = MAC;
+		else if (os.contains("win")) current = WIN;
+		else if (os.contains("nux")) current = LINUX;
+		else current = OTHER;
+	}
+}

--- a/src/main/java/fxlauncher/model/lifecycle/LifecycleListener.java
+++ b/src/main/java/fxlauncher/model/lifecycle/LifecycleListener.java
@@ -1,0 +1,10 @@
+package fxlauncher.model.lifecycle;
+
+/**
+ * Interface that classes must implement if they want to be notified
+ * when the current {@link LifecyclePhase} changes
+ * @author idavis1
+ */
+public interface LifecycleListener {
+	public void notifyListener();
+}

--- a/src/main/java/fxlauncher/model/lifecycle/LifecyclePhase.java
+++ b/src/main/java/fxlauncher/model/lifecycle/LifecyclePhase.java
@@ -1,5 +1,7 @@
 package fxlauncher.model.lifecycle;
 
+import static java.util.logging.Logger.getLogger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -28,7 +30,7 @@ public enum LifecyclePhase {
 	APPLICATION_START,
 	;
 	
-	private static Logger log = Logger.getLogger(LifecyclePhase.class.getName());
+	private static Logger log = getLogger(LifecyclePhase.class.getName());
 	
 	public static LifecyclePhase current = STARTUP;
 	
@@ -40,9 +42,10 @@ public enum LifecyclePhase {
 	 * @param phase the new current phase
 	 */
 	public static void setCurrent(LifecyclePhase phase) {
+		log.fine(String.format("exiting launcher lifecycle phase ", current.toString()));
 		LifecyclePhase.current.exitPhaseListeners.forEach(LifecycleListener::notifyListener);
-		log.fine("beginning launcher lifecycle phase");
 		current = phase;
+		log.fine(String.format("beginning launcher lifecycle phase ", current.toString()));
 		LifecyclePhase.current.enterPhaseListeners.forEach(LifecycleListener::notifyListener);
 	}
 	

--- a/src/main/java/fxlauncher/model/lifecycle/LifecyclePhase.java
+++ b/src/main/java/fxlauncher/model/lifecycle/LifecyclePhase.java
@@ -1,0 +1,64 @@
+package fxlauncher.model.lifecycle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+
+/**
+ * Enumeration lists the phases of the default lifecycle of a
+ * running FxLauncher instance, keeps track of the current phase, 
+ * and notifies registered listeners when the phase changes
+ * @author idavis1
+ */
+public enum LifecyclePhase {
+	STARTUP,
+	LOAD_EMBEDDED_CONFIG,
+	PARSE_CLI_ARGS,
+	LOAD_REMOTE_CONFIG,
+	FETCH_EXPLICIT_MANIFEST,
+	FETCH_CACHED_MANIFEST,
+	FETCH_REMOTE_MANIFEST,
+	WRITE_MANIFEST_TO_CACHE,
+	SYNC_ARTIFACTS,
+	PREPARE_APPLICATION_ENVIRONMENT,
+	LOAD_SYSTEM_LIBS,
+	CREATE_APPLICATION,
+	APPLICATION_INIT,
+	APPLICATION_START,
+	;
+	
+	private static Logger log = Logger.getLogger(LifecyclePhase.class.getName());
+	
+	public static LifecyclePhase current = STARTUP;
+	
+	private List<LifecycleListener> enterPhaseListeners = new ArrayList<>();
+	private List<LifecycleListener> exitPhaseListeners = new ArrayList<>();
+
+	/**
+	 * Move to a new current lifecycle phase and notify listeners
+	 * @param phase the new current phase
+	 */
+	public static void setCurrent(LifecyclePhase phase) {
+		LifecyclePhase.current.exitPhaseListeners.forEach(LifecycleListener::notifyListener);
+		log.fine("beginning launcher lifecycle phase");
+		current = phase;
+		LifecyclePhase.current.enterPhaseListeners.forEach(LifecycleListener::notifyListener);
+	}
+	
+	/**
+	 * add a listener to be notified when entering this phase
+	 * @param listener the {@link LifecycleListener} to add
+	 */
+	public void registerEnterListener(LifecycleListener listener) {
+		this.enterPhaseListeners.add(listener);
+	}
+	
+	/**
+	 * add a listener to be notified when exiting this phase
+	 * @param listener the {@link LifecycleListener} to add
+	 */
+	public void registerExitListener(LifecycleListener listener) {
+		this.exitPhaseListeners.add(listener);
+	}
+}

--- a/src/main/java/fxlauncher/old/AbstractLauncher.java
+++ b/src/main/java/fxlauncher/old/AbstractLauncher.java
@@ -1,9 +1,12 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javafx.application.Application;
 
 import javax.net.ssl.*;
 import javax.xml.bind.JAXB;
+
+import static fxlauncher.old.Strings.ensureEndingSlash;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,8 +30,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 import java.util.stream.Collectors;
-
-import static fxlauncher.Strings.ensureEndingSlash;
 
 @SuppressWarnings("unchecked")
 public abstract class AbstractLauncher<APP>  {

--- a/src/main/java/fxlauncher/old/CreateManifest.java
+++ b/src/main/java/fxlauncher/old/CreateManifest.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javax.xml.bind.JAXB;
 import java.io.IOException;

--- a/src/main/java/fxlauncher/old/DefaultUIProvider.java
+++ b/src/main/java/fxlauncher/old/DefaultUIProvider.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javafx.geometry.Insets;
 import javafx.scene.Parent;

--- a/src/main/java/fxlauncher/old/FXManifest.java
+++ b/src/main/java/fxlauncher/old/FXManifest.java
@@ -1,9 +1,12 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javax.xml.bind.JAXB;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import static fxlauncher.old.Strings.ensureEndingSlash;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,8 +17,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
-
-import static fxlauncher.Strings.ensureEndingSlash;
 
 @SuppressWarnings("unchecked")
 @XmlRootElement(name = "Application")

--- a/src/main/java/fxlauncher/old/FxlauncherClassCloader.java
+++ b/src/main/java/fxlauncher/old/FxlauncherClassCloader.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import java.io.File;
 import java.net.MalformedURLException;

--- a/src/main/java/fxlauncher/old/HeadlessMainLauncher.java
+++ b/src/main/java/fxlauncher/old/HeadlessMainLauncher.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javafx.application.Application;
 

--- a/src/main/java/fxlauncher/old/Launcher.java
+++ b/src/main/java/fxlauncher/old/Launcher.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import com.sun.javafx.application.PlatformImpl;
 import javafx.application.Application;

--- a/src/main/java/fxlauncher/old/LauncherParams.java
+++ b/src/main/java/fxlauncher/old/LauncherParams.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javafx.application.Application;
 

--- a/src/main/java/fxlauncher/old/LibraryFile.java
+++ b/src/main/java/fxlauncher/old/LibraryFile.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import java.io.IOException;

--- a/src/main/java/fxlauncher/old/OS.java
+++ b/src/main/java/fxlauncher/old/OS.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 enum OS {
 	win, mac, linux, other;

--- a/src/main/java/fxlauncher/old/Strings.java
+++ b/src/main/java/fxlauncher/old/Strings.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 public class Strings {
     public static String ensureEndingSlash(String s) {

--- a/src/main/java/fxlauncher/old/UIProvider.java
+++ b/src/main/java/fxlauncher/old/UIProvider.java
@@ -1,4 +1,4 @@
-package fxlauncher;
+package fxlauncher.old;
 
 import javafx.scene.Parent;
 import javafx.stage.Stage;


### PR DESCRIPTION
## Problem Statement
Current implementation of configurable options is ad-hoc and based on Strings.

## Proposed fix
Centralize and standardize the set of configurable options for the Launcher program in an enumerated type with responibility for:
* giving each option an constant Java symbol that represents it
* defining the String that will be used to associate a given command-line entry or member of a Java properties file with the option
* supplying default values for each option
* providing validation logic for each option
* providing a `Resolver` mechanism for any needed transformation of an option (i.e., as with the ALLUSERS and USERLIB path sections in `CACHE_DIR`).
* tracking when in the FxLauncher's lifecycle a particular property was set

## Steps taken
1. Introduced several new packages to organize functionality
1. Introduced the described enum class
1. Introduced supporting enums `GenericPathLabel` and `OS` that together have responsibility for resolving the ALLUSERS and USERLIB sentinels
1. Introduced a `Resolver` interface, which extends `UnaryOperator<String>` along with some default implementations
1. Introduced a `Validator` interface which extends `Predicate<String>` along with some default implementations

## Additional steps taken that are not necessarily relevant to the current work but will affect later-planned work.
1. Added enum LifecyclePhase that acts as a very simple state machine and implements an Observable pattern
1. Added a LifecycleListener interface that Observers of LifecyclePhase must implement
1. Added application-specific Exception types