### PR TITLE
[NOT IMPORTANT] adding javadoc bits

### DIFF
--- a/src/main/java/fxlauncher/model/GenericPathLabel.java
+++ b/src/main/java/fxlauncher/model/GenericPathLabel.java
@@ -1,8 +1,8 @@
 package fxlauncher.model;
 
 /**
- * Sentinel values that can be embedded in {@link LauncherConfig}
- * entries representing paths. Adding a suitable {@link Resolver}
+ * Sentinel values that can be embedded in {@link fxlauncher.config.LauncherOption}
+ * entries representing paths. Adding a suitable {@link fxlauncher.config.Resolver}
  * should replace the string-equivalents of these values with the
  * appropriate Operating-System-specific paths.
  * 

--- a/src/main/java/fxlauncher/old/AbstractLauncher.java
+++ b/src/main/java/fxlauncher/old/AbstractLauncher.java
@@ -42,7 +42,7 @@ public abstract class AbstractLauncher<APP>  {
      * Make java.util.logger log to a file. Default it will log to $TMPDIR/fxlauncher.log. This can be overriden by using
      * comman line parameter <code>--logfile=logfile</code>
      *
-     * @throws IOException
+     * @throws IOException when Log file not found or uneditable.
      */
     protected void setupLogFile() throws IOException {
         String filename = System.getProperty("java.io.tmpdir") + File.separator + "fxlauncher.log";
@@ -57,8 +57,8 @@ public abstract class AbstractLauncher<APP>  {
     /**
      * Check if the SSL connection needs to ignore the validity of the ssl certificate.
      *
-     * @throws KeyManagementException
-     * @throws NoSuchAlgorithmException
+     * @throws KeyManagementException if key is not available
+     * @throws NoSuchAlgorithmException if algorithm is invalid
      */
     protected void checkSSLIgnoreflag() throws KeyManagementException, NoSuchAlgorithmException {
         if (getParameters().getUnnamed().contains("--ignoressl")) {
@@ -96,7 +96,7 @@ public abstract class AbstractLauncher<APP>  {
      * Also return false and do not check for updates if the <code>--offline</code> commandline argument is set.
      *
      * @return true if new files have been downloaded, false otherwise.
-     * @throws Exception
+     * @throws Exception if the files cannot be downloaded
      */
     protected boolean syncFiles() throws Exception {
 

--- a/src/main/java/fxlauncher/old/CreateManifest.java
+++ b/src/main/java/fxlauncher/old/CreateManifest.java
@@ -178,7 +178,7 @@ public class CreateManifest {
      * <p>
      * Although the method is called setIncludeExtensions, it actually does an addAll.
      *
-     * @param includeExtensions
+     * @param includeExtensions a list of extensions that should be included in the manifest
      */
     public static void setIncludeExtensions(List<String> includeExtensions) {
         CreateManifest.includeExtensions.addAll(includeExtensions);

--- a/src/main/java/fxlauncher/old/UIProvider.java
+++ b/src/main/java/fxlauncher/old/UIProvider.java
@@ -53,6 +53,7 @@ public interface UIProvider {
 	 *
 	 * @see #updateProgress(double)
 	 * @return The updater Node
+	 * @param manifest a manifest that contains style data
 	 */
 	Parent createUpdater(FXManifest manifest);
 


### PR DESCRIPTION
## Problem statement
The maven-javadoc-plugin is choking on a handful of javadoc comments that have either incomplete tags, or reference classes that don't exist yet or aren't fully-qualifed.

## Proposed Fix
Supply comments on tags where needed, remove or replace references to not-yet-created classes, replace class names with fully-qualified names where appropriate.

## Notes
* most of this code is going to be eliminated later. Just trying to give myself fewer headaches while I work on this.