### PR TITLE
Implement launcher config

### DIFF
--- a/src/main/java/fxlauncher/config/LauncherConfig.java
+++ b/src/main/java/fxlauncher/config/LauncherConfig.java
@@ -1,0 +1,74 @@
+package fxlauncher.config;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.logging.Logger;
+
+import fxlauncher.except.FXLauncherConfigException;
+import fxlauncher.model.lifecycle.LifecyclePhase;
+
+/**
+ * Class represents the current configuration state of the FXLauncher
+ * application itself, and provides methods for changing that state.
+ *
+ * Class is internally a singleton, accessed by static methods.
+ *
+ * @author idavis1
+ */
+public class LauncherConfig {
+
+	private final static Logger log = Logger.getLogger(LauncherConfig.class.getName());
+
+	private final Map<LauncherOption, String> configMap = new EnumMap<LauncherOption, String>(LauncherOption.class);
+	private static final LauncherConfig instance = new LauncherConfig();
+
+	/**
+	 * update the current state value of a {@link LauncherOption}.
+	 *
+	 * Before storing the value, performs any validation and transformation defined
+	 * in the {@link LauncherOption} instance.
+	 *
+	 * @param option the {@link LauncherOption} to be associated with a value
+	 * @param value  the value to be associated
+	 */
+	public static void setOption(LauncherOption option, String value) {
+		log.finer(ATTEMPT_SET_MSG.apply(option, value));
+		String resolved = option.getResolver().apply(value);
+		if (!value.equals(resolved))
+			log.finer(RESOLVED_MSG.apply(value, resolved));
+		validateOptionValue(option, value);
+
+		instance.configMap.put(option, resolved);
+		option.recordOptionSet(LifecyclePhase.current);
+		log.fine(OPTION_SET_MSG.apply(option, resolved));
+	}
+
+	/**
+	 * Fetch any value currently associated with the given {@link LauncherOption},
+	 *
+	 * @param option the {@link LauncherOption} to be retrieved
+	 * @return the explicitly-set value associated with the given
+	 *         {@link LauncherOption}, or a suitable default if no explicit value is
+	 *         present
+	 */
+	public static String getOption(LauncherOption option) {
+		return instance.configMap.getOrDefault(option, option.getDefault());
+	}
+
+	private static void validateOptionValue(LauncherOption option, String value) {
+		if (!option.getValidator().test(value)) {
+			throw new FXLauncherConfigException(
+					String.format("Cannot ingest invalid value '%s' into option '%s'. Not a valid value. Expected %s",
+							value, option, Validator.getExpected(option.getValidator())));
+		}
+	}
+
+	private static final BiFunction<LauncherOption, String, String> ATTEMPT_SET_MSG = (opt, val) -> String
+			.format("Attempting to set LauncherOption.%s to value '%s'", opt, val);
+	private static final BinaryOperator<String> RESOLVED_MSG = (unresolved, resolved) -> String
+			.format("Input '%s' resolved to '%s'", unresolved, resolved);
+	private static final BiFunction<LauncherOption, String, String> OPTION_SET_MSG = (opt, val) -> String
+			.format("Successfully set option '%s' to '%s'", opt, val);
+}

--- a/src/main/java/fxlauncher/config/LoggerConfig.java
+++ b/src/main/java/fxlauncher/config/LoggerConfig.java
@@ -1,0 +1,38 @@
+package fxlauncher.config;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.function.UnaryOperator;
+import java.util.logging.FileHandler;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import fxlauncher.old.Launcher;
+
+public class LoggerConfig {
+
+	/**
+	 * Set the local logfile based on {@link LauncherOption} {@code LOG_FILE}
+	 *
+	 * @param logfile the file that log messages should be sent to
+	 */
+	public static void initLocalLogging(String logfile) {
+		Logger appRootLog = Logger.getLogger(Launcher.class.getPackage().getName());
+		Logger log = Logger.getLogger(LoggerConfig.class.getName());
+
+		FileHandler handler;
+		log.info("Attempting to begin logging to " + logfile);
+		try {
+			handler = new FileHandler(logfile);
+			handler.setFormatter(new SimpleFormatter());
+			appRootLog.addHandler(handler);
+			appRootLog.info("now logging to " + logfile);
+		} catch (SecurityException | IOException e) {
+			log.warning(CREATE_HANDLER_FAILED_MSG.apply(logfile));
+			e.printStackTrace();
+		}
+	}
+
+	private final static UnaryOperator<String> CREATE_HANDLER_FAILED_MSG = logfile -> String.format(
+			"Unable to log to '%s'. Logging to default location instead: %s", logfile, Paths.get(".").toAbsolutePath());
+}

--- a/src/main/java/fxlauncher/config/SSLConfig.java
+++ b/src/main/java/fxlauncher/config/SSLConfig.java
@@ -1,0 +1,53 @@
+package fxlauncher.config;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.logging.Logger;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public class SSLConfig {
+
+	private static final Logger log = Logger.getLogger(SSLConfig.class.getName());
+
+	public static void init(Boolean ignoreSSL) {
+		if (!ignoreSSL)
+			return;
+
+		log.info("Attempting to ignore SSL exceptions");
+		TrustManager[] trustManager = new TrustManager[] { new X509TrustManager() {
+			@Override
+			public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+			}
+
+			@Override
+			public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+			}
+
+			@Override
+			public X509Certificate[] getAcceptedIssuers() {
+				return null;
+			}
+		} };
+		SSLContext sslContext;
+
+		try {
+			sslContext = SSLContext.getInstance("SSL");
+			sslContext.init(null, trustManager, new java.security.SecureRandom());
+			HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+		} catch (NoSuchAlgorithmException | KeyManagementException e) {
+			log.warning("failed to ignore SSL exceptions");
+			e.printStackTrace();
+		}
+
+		log.info("SSL exceptions are ignored");
+		HostnameVerifier hostnameVerifier = (s, sslSession) -> true;
+		HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
+	}
+}

--- a/src/main/java/fxlauncher/config/ingest/ArgsIngester.java
+++ b/src/main/java/fxlauncher/config/ingest/ArgsIngester.java
@@ -1,0 +1,82 @@
+package fxlauncher.config.ingest;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.stream.Stream;
+
+import fxlauncher.config.LauncherConfig;
+import fxlauncher.config.LauncherOption;
+
+/**
+ * Concrete implemention of {@link ConfigurationIngester} that deduces
+ * {@link LauncherConfig} settings from command-line arguments (or any other
+ * String array);
+ *
+ * @author idavis1
+ *
+ */
+public class ArgsIngester extends ConfigurationIngester {
+
+	private static final Logger log = Logger.getLogger(ArgsIngester.class.getName());
+
+	private String[] args = new String[0];
+
+	public ArgsIngester() {
+		super();
+	}
+
+	public ArgsIngester(String... args) {
+		super();
+		this.args = args;
+	}
+
+	// -- invoked by superclass when ingestParams() is called.
+	@Override
+	protected List<String> _ingestParams() {
+		log.info(BEGIN_MSG.apply(args));
+		List<String> leftovers = Stream.of(args).filter(this::matchAndExtract).collect(toList());
+		return leftovers;
+	}
+
+	/**
+	 * Fluent interface for setting the set of arguments to be ingested
+	 *
+	 * @param args the array of arguments to be ingested
+	 * @return this ArgsIngester object, so that further operations can be performed
+	 *         on it.
+	 */
+	public ArgsIngester forArgs(String[] args) {
+		this.args = args;
+		return this;
+	}
+
+	private boolean matchAndExtract(String arg) {
+		for (LauncherOption opt : LauncherOption.values()) {
+			Matcher matcher = opt.getMatcher(arg);
+			if (matcher.find()) {
+				log.finer(MATCHED_OPT_MSG.apply(arg, opt.toString()));
+				String value = matcher.group(1);
+				LauncherConfig.setOption(opt, value);
+				return false;
+			} else {
+				log.finer(UNMATCHED_OPT_MSG.apply(arg));
+				continue;
+			}
+		}
+		return true;
+	}
+
+	private static final Function<String[], String> BEGIN_MSG = args -> String
+			.format("Ingesting command-line arguments: %s", Stream.of(args).collect(joining(",", "[", "]")));
+	private static final BinaryOperator<String> MATCHED_OPT_MSG = (arg, opt) -> String
+			.format("Matched argument '%s' with LauncherOption '%s'", arg, opt);
+	private static final UnaryOperator<String> UNMATCHED_OPT_MSG = (arg) -> String
+			.format("No matching LauncherOption found for argument: '%s'. Sending to downstream application", arg);
+}

--- a/src/main/java/fxlauncher/config/ingest/ConfigurationIngester.java
+++ b/src/main/java/fxlauncher/config/ingest/ConfigurationIngester.java
@@ -1,0 +1,50 @@
+package fxlauncher.config.ingest;
+
+import java.util.List;
+
+import fxlauncher.downstream.DownstreamParameters;
+
+/**
+ * Base class for all classes that read in a source of FxLauncher configuration
+ * data. Subclasses are expected to implement the
+ * {@code _ingestParams()) method and
+ * return the set of ingested options that do not match any {@link
+ * LauncherOption} value.
+ *
+ * @author idavis1
+ */
+public abstract class ConfigurationIngester {
+
+	// if no link DownstreamParameters object is provided, use a do-nothing one that
+	// will be discarded by the trash-collector later.
+	private static DownstreamParameters defaultDownstreamParams = new DownstreamParameters();
+
+	protected boolean overwriteArgs = true;
+	protected DownstreamParameters downstreamParams = defaultDownstreamParams;
+
+	// set for all new instances
+	public static void setDefaultDownstreamParams(DownstreamParameters downstreamParams) {
+		ConfigurationIngester.defaultDownstreamParams = downstreamParams;
+	}
+
+	/**
+	 * Initiate implementation-specific ingest process and stash the overflow in a
+	 * {@link DownstreamParameters} object.
+	 */
+	public void ingest() {
+		List<String> leftovers = _ingestParams();
+		leftovers.forEach(arg -> downstreamParams.merge(arg, overwriteArgs));
+	}
+
+	public ConfigurationIngester storeDownstreamParamsIn(DownstreamParameters downstreamParams) {
+		this.downstreamParams = downstreamParams;
+		return this;
+	}
+
+	/**
+	 * Must-override method containing implementation-specific ingest logic
+	 *
+	 * @return a list of ingested options not used by FxLauncher itself
+	 */
+	protected abstract List<String> _ingestParams();
+}

--- a/src/main/java/fxlauncher/config/ingest/PropertiesFileIngester.java
+++ b/src/main/java/fxlauncher/config/ingest/PropertiesFileIngester.java
@@ -21,6 +21,17 @@ import fxlauncher.tools.io.ClasspathResourceFetcher;
  * Implementation of {@link ConfigurationIngester} that reads values in from a
  * Java properties file.
  *
+ * @implNote using {@link Supplier<String>} to provide the configuration
+ *           filename allows resolution of the value when {@code _ingest()} is
+ *           invoked, rather than at or before execution of the constructor.
+ *           This is useful when another {@link ConfigurationIngester} changes
+ *           the configuration state after this object is constructed, but
+ *           before its {@code _ingest()} method runs. We always want to run
+ *           {@code _ingest()} based on the current state at the time of
+ *           execution. In the case where this value is not expected to be
+ *           changed, a String can be provided and this class will construct the
+ *           appropriate Supplier for it.
+ *
  * @author idavis1
  *
  */
@@ -30,10 +41,6 @@ public class PropertiesFileIngester extends ConfigurationIngester {
 
 	private final Properties props = new Properties();
 
-	// using Supplier here allows the source to be defined at construction-time, but
-	// not retrieved before _ingest() is invoked. This is handy when another
-	// ConfigurationIngester can change configuration state after this object is
-	// constructed, but before the _ingest() method is invoked.
 	private Supplier<String> resourceNameSupplier = () -> LauncherOption.CONFIG_FILE.getDefault();
 
 	public PropertiesFileIngester() {

--- a/src/main/java/fxlauncher/config/ingest/PropertiesFileIngester.java
+++ b/src/main/java/fxlauncher/config/ingest/PropertiesFileIngester.java
@@ -1,0 +1,146 @@
+package fxlauncher.config.ingest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import fxlauncher.config.LauncherConfig;
+import fxlauncher.config.LauncherOption;
+import fxlauncher.tools.io.ClasspathResourceFetcher;
+
+/**
+ * Implementation of {@link ConfigurationIngester} that reads values in from a
+ * Java properties file.
+ *
+ * @author idavis1
+ *
+ */
+public class PropertiesFileIngester extends ConfigurationIngester {
+
+	private static final Logger log = Logger.getLogger(PropertiesFileIngester.class.getName());
+
+	private final Properties props = new Properties();
+
+	// using Supplier here allows the source to be defined at construction-time, but
+	// not retrieved before _ingest() is invoked. This is handy when another
+	// ConfigurationIngester can change configuration state after this object is
+	// constructed, but before the _ingest() method is invoked.
+	private Supplier<String> resourceNameSupplier = () -> LauncherOption.CONFIG_FILE.getDefault();
+
+	public PropertiesFileIngester() {
+		super();
+	}
+
+	public PropertiesFileIngester(String resourceName) {
+		super();
+		this.resourceNameSupplier = () -> resourceName;
+	}
+
+	public PropertiesFileIngester(Supplier<String> resourceNameSupplier) {
+		super();
+		this.resourceNameSupplier = resourceNameSupplier;
+	}
+
+	/**
+	 * Fluent interface for setting the {@code resourceName} member.
+	 *
+	 * @param resourceName the static name of a resource containing configuration
+	 *                     settings as Java properties
+	 * @return this PropertiesFileIngester object, so that further operations can be
+	 *         performed on it
+	 */
+	public PropertiesFileIngester forPropertyFile(String resourceName) {
+		this.resourceNameSupplier = () -> resourceName;
+		return this;
+	}
+
+	/**
+	 * Fluent interface for setting the {@code resourceName} member.
+	 *
+	 * @param resourceName a {@link Supplier} of the name of a resource containing
+	 *                     configuration settings as Java properties
+	 * @return this PropertiesFileIngester object, so that further operations can be
+	 *         performed on it
+	 */
+	public PropertiesFileIngester forPropertyFile(Supplier<String> resourceNameSupplier) {
+		this.resourceNameSupplier = resourceNameSupplier;
+		return this;
+	}
+
+	// invoked by superclass -- ingest properties from the named resource
+	@Override
+	protected List<String> _ingestParams() {
+		loadEmbeddedProps(resourceNameSupplier.get());
+		props.forEach(this::matchAndExtract);
+		return props.entrySet().stream().map(PropertiesFileIngester::formatProperty).collect(Collectors.toList());
+	}
+
+	private void loadEmbeddedProps(String resourceName) {
+		log.fine(NOTIFY_MSG.apply(resourceName));
+		Optional<InputStream> fetched = new ClasspathResourceFetcher(resourceName).fetch();
+
+		if (fetched.isPresent()) {
+			log.info(FOUND_MSG.apply(resourceName));
+			try {
+				props.load(fetched.get());
+			} catch (IOException e) {
+				log.warning(INVALID_MSG.apply(resourceName));
+				e.printStackTrace();
+			}
+		}
+
+		log.info(NOT_FOUND_MSG);
+	}
+
+	private void matchAndExtract(Object keyObj, Object valueObj) {
+		String key = keyObj.toString();
+		String value = valueObj.toString();
+
+		log.finer(INGEST_PROP_MSG.apply(key, value));
+		for (LauncherOption opt : LauncherOption.values()) {
+			if (key.equals(opt.getLabel())) {
+				log.finer(MATCHED_OPT_MSG.apply(key, opt.toString()));
+				LauncherConfig.setOption(opt, value);
+				props.remove(keyObj);
+			}
+			return;
+		}
+		log.finer(UNMATCHED_OPT_MSG.apply(key));
+	}
+
+	private static String formatProperty(Map.Entry<Object, Object> property) {
+		return (property.getValue() == null) ? UNNAMED_PROP_FMT.apply(property) : NAMED_PROP_FMT.apply(property);
+	}
+
+	// just giving convenient names to some simple but cumbersome String formatting
+	// logic to improve readability above this comment
+	private static final UnaryOperator<String> NOTIFY_MSG = resourceName -> String
+			.format("Importing embedded properties resource: %s", resourceName);
+	private static final UnaryOperator<String> FOUND_MSG = resourceName -> String
+			.format("Found embedded properties file %s", resourceName);
+	private static final UnaryOperator<String> INVALID_MSG = resourceName -> String
+			.format("Failed to load embedded properties file '%s'. Check file format/syntax", resourceName);
+	private static final String NOT_FOUND_MSG = "No embedded properties file found";
+
+	private static final BinaryOperator<String> INGEST_PROP_MSG = (key, value) -> String
+			.format("Attempting to property with key=%s and value=%s...", key, value);
+	private static final BinaryOperator<String> MATCHED_OPT_MSG = (key, opt) -> String
+			.format("Matched property key '%s' to LauncherOption '%s'...", key, opt);
+	private static final UnaryOperator<String> UNMATCHED_OPT_MSG = key -> String
+			.format("No LauncherOption found to match property key '%s'. Passing along to downstream app", key);
+
+	private static final Function<Map.Entry<Object, Object>, String> NAMED_PROP_FMT = prop -> String.format("--%s=%s",
+			prop.getKey().toString(), prop.getValue().toString());
+	private static final Function<Map.Entry<Object, Object>, String> UNNAMED_PROP_FMT = prop -> String.format("--%s",
+			prop.getKey().toString());
+
+}

--- a/src/main/java/fxlauncher/downstream/DownstreamParameters.java
+++ b/src/main/java/fxlauncher/downstream/DownstreamParameters.java
@@ -1,0 +1,122 @@
+package fxlauncher.downstream;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javafx.application.Application;
+
+/**
+ * Subclass of JavaFX's abstract {@link Application.Parameters} meant to collect
+ * all arguments provided to FxLauncher, but not explicitly used by FxLauncher.
+ * The assumption is that these are meant for the downstream application.
+ *
+ * Also provides the same service for non-JavaFX downstream applications
+ * launched via their {@code main()} method by allowing retrieval of the
+ * rawParams member as an array.
+ *
+ * @author idavis1
+ *
+ */
+public class DownstreamParameters extends Application.Parameters {
+
+	private static final Pattern NAMED_PATTERN = Pattern.compile("--(?<key>.\\+)=(?<value>.\\+)");
+
+	// use Set to simply enforce uniqueness
+	private static Set<String> rawParams = new HashSet<>();
+	private static Set<String> unnamedParams = new HashSet<>();
+	private static Map<String, String> namedParams = new HashMap<>();
+
+	/**
+	 * Return the set of raw arguments
+	 */
+	@Override
+	public List<String> getRaw() {
+		return new ArrayList<>(rawParams);
+	}
+
+	/**
+	 * Return the set of unnamed arguments (i.e. those not of the format
+	 * '--key=value')
+	 */
+	@Override
+	public List<String> getUnnamed() {
+		return new ArrayList<>(unnamedParams);
+	}
+
+	/**
+	 * Return the set of named arguments (i.e. those of the format '--key=value')
+	 */
+	@Override
+	public Map<String, String> getNamed() {
+		return namedParams;
+	}
+
+	/**
+	 * Return the set of arguments as a String array This is useful when trying to
+	 * launch the downstream program via a {@code main()} method.
+	 *
+	 * @return the set of arguments as an array
+	 */
+	public String[] getArgs() {
+		return rawParams.parallelStream().toArray(String[]::new);
+	}
+
+	/**
+	 * Add the argument to the set of downstream parameters, unless it is already
+	 * present in the set
+	 *
+	 * Useful when ingesting a manifest to avoid overwriting any
+	 * {@link LauncherConfig} options that were explicitly set by command-line args,
+	 * embedded configuration files, or remote overrides
+	 *
+	 * @param string the argument to be merged into the set of Parameters
+	 */
+	public void mergeIfNotPresent(String string) {
+		merge(string, false);
+	}
+
+	/**
+	 * Add the argument to the set of downstream parameters, overwriting any
+	 * pre-existing value
+	 *
+	 * Useful when ingesting initial configuration data from command-line args,
+	 * embedded configuration files, and remote overrides, where precedence is set
+	 * by order and each should override the previous sets of configuration.
+	 *
+	 * @param string the argument to be merged into the set of Parameters
+	 */
+	public void mergeOverwriting(String string) {
+		merge(string, true);
+	}
+
+	/**
+	 * Generic merge method that hands both overwriting and non-overwriting cases
+	 *
+	 * note that overwriting only applies to named parameters uniqueness of
+	 * non-named parameters and CLI arguments is ensured by the use of a Set
+	 * internally.
+	 *
+	 * @param string    the argument to be merged into the set of Parameters
+	 * @param overwrite a boolean indicating whether existing parameters should be
+	 *                  overwritten
+	 */
+	public void merge(String string, boolean overwrite) {
+		Matcher matcher = NAMED_PATTERN.matcher(string);
+		if (matcher.find()) {
+			String key = matcher.group("key");
+			String value = matcher.group("value");
+			if (overwrite || !namedParams.containsKey(key)) {
+				namedParams.put(key, value);
+			}
+		} else {
+			unnamedParams.add(string);
+		}
+		rawParams.add(string);
+	}
+}

--- a/src/main/java/fxlauncher/tools/io/ClasspathResourceFetcher.java
+++ b/src/main/java/fxlauncher/tools/io/ClasspathResourceFetcher.java
@@ -1,0 +1,30 @@
+package fxlauncher.tools.io;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+import fxlauncher.except.FXLauncherException;
+import fxlauncher.old.Launcher;
+
+/**
+ * Implementation of {@link FileFetcher} that retrieves a resource from the
+ * classpath by its name
+ *
+ * @author idavis1
+ */
+public class ClasspathResourceFetcher implements FileFetcher {
+
+	private final String resourceName;
+
+	public ClasspathResourceFetcher(String resourceName) {
+		this.resourceName = resourceName;
+	}
+
+	/**
+	 * Retrieves the resource named in {@code resourceName} from the classpath
+	 */
+	@Override
+	public Optional<InputStream> fetch() throws FXLauncherException {
+		return Optional.ofNullable(Launcher.class.getResourceAsStream(resourceName));
+	}
+}

--- a/src/main/java/fxlauncher/tools/io/ClasspathResourceFetcher.java
+++ b/src/main/java/fxlauncher/tools/io/ClasspathResourceFetcher.java
@@ -2,6 +2,7 @@ package fxlauncher.tools.io;
 
 import java.io.InputStream;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 import fxlauncher.except.FXLauncherException;
 import fxlauncher.old.Launcher;
@@ -14,6 +15,8 @@ import fxlauncher.old.Launcher;
  */
 public class ClasspathResourceFetcher implements FileFetcher {
 
+	private final static Logger log = Logger.getLogger(ClasspathResourceFetcher.class.getName());
+
 	private final String resourceName;
 
 	public ClasspathResourceFetcher(String resourceName) {
@@ -25,6 +28,7 @@ public class ClasspathResourceFetcher implements FileFetcher {
 	 */
 	@Override
 	public Optional<InputStream> fetch() throws FXLauncherException {
+		log.fine("Fetching resource " + resourceName);
 		return Optional.ofNullable(Launcher.class.getResourceAsStream(resourceName));
 	}
 }

--- a/src/main/java/fxlauncher/tools/io/FileFetcher.java
+++ b/src/main/java/fxlauncher/tools/io/FileFetcher.java
@@ -1,0 +1,16 @@
+package fxlauncher.tools.io;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+import fxlauncher.except.FXLauncherException;
+
+/**
+ * Standardized interface for fetching resources via I/O
+ *
+ * @author idavis1
+ *
+ */
+public interface FileFetcher {
+	public Optional<InputStream> fetch() throws FXLauncherException;
+}


### PR DESCRIPTION
## Problem Statement
The new implementation portion of the launcher has configuration options, but no tracking of configuration state, nor any way to read that state in from an external source.

## Proposed Fix
Introduce a configuration-state class, a configuration ingestion interface with concrete implementations for ingesting from an embedded properties file and command-line arguments, along with any supporting classes needed.

## Steps Taken
* Added `DownstreamParameters` (an implementation of `javafx.application.Application.Parameters`). The purpose of this class is to capture any ingested options not used by the launcher itself for the purpose of passing them along to the downstream application. Also provides a means of retrieving those parameters as a String array to be passed to a `main()` method.
* Added `FileFetcher` interface, which provides a standardized interface for performing simple I/O. In the original FXLauncher, some of this logic was duplicated in multiple places, and used different return types. This way, every I/O fetch returns an Optional<InputStream> so that consumers can digest fetched data in the same way, no matter how the data was fetched.
* Added `ClasspathResourceFetcher`, an implementation of `FileFetcher` that fetches a resource off the classpath by its name.
* Added `ConfigurationIngester` abstract class and two concrete implementations: `ArgsIngester` and `PropertiesFileIngester`.
* Added `LoggerConfig` and `SSLConfig`. These are essentially unchanged from the way the original FXLauncher handled these configuration options, except that the logic for each has been isolated into its own class now.
* Added `LauncherConfig`, the implementation of configuration state and state-changing operations.