### PR TITLE
Add launcher config tests

### DIFF
--- a/src/main/java/fxlauncher/LauncherMain.java
+++ b/src/main/java/fxlauncher/LauncherMain.java
@@ -1,0 +1,8 @@
+package fxlauncher;
+
+public class LauncherMain {
+
+	public static void main(String[] args) {
+		// NOOP
+	}
+}

--- a/src/main/java/fxlauncher/config/LauncherConfig.java
+++ b/src/main/java/fxlauncher/config/LauncherConfig.java
@@ -1,5 +1,7 @@
 package fxlauncher.config;
 
+import static java.util.logging.Logger.getLogger;
+
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -10,65 +12,70 @@ import fxlauncher.except.FXLauncherConfigException;
 import fxlauncher.model.lifecycle.LifecyclePhase;
 
 /**
- * Class represents the current configuration state of the FXLauncher
- * application itself, and provides methods for changing that state.
+ * Class represents the current configuration state of the FXLauncher application itself, and
+ * provides methods for changing that state.
  *
- * Class is internally a singleton, accessed by static methods.
+ * <p>Class is internally a singleton, accessed by static methods.
  *
  * @author idavis1
  */
 public class LauncherConfig {
 
-	private final static Logger log = Logger.getLogger(LauncherConfig.class.getName());
+  private static final Logger log = getLogger(LauncherConfig.class.getName());
+  private static final LauncherConfig instance = new LauncherConfig();
 
-	private final Map<LauncherOption, String> configMap = new EnumMap<LauncherOption, String>(LauncherOption.class);
-	private static final LauncherConfig instance = new LauncherConfig();
+  private final Map<LauncherOption, String> configMap =
+      new EnumMap<LauncherOption, String>(LauncherOption.class);
 
-	/**
-	 * update the current state value of a {@link LauncherOption}.
-	 *
-	 * Before storing the value, performs any validation and transformation defined
-	 * in the {@link LauncherOption} instance.
-	 *
-	 * @param option the {@link LauncherOption} to be associated with a value
-	 * @param value  the value to be associated
-	 */
-	public static void setOption(LauncherOption option, String value) {
-		log.finer(ATTEMPT_SET_MSG.apply(option, value));
-		String resolved = option.getResolver().apply(value);
-		if (!value.equals(resolved))
-			log.finer(RESOLVED_MSG.apply(value, resolved));
-		validateOptionValue(option, value);
+  static void restoreDefaults() {
+    instance.configMap.clear();
+  }
 
-		instance.configMap.put(option, resolved);
-		option.recordOptionSet(LifecyclePhase.current);
-		log.fine(OPTION_SET_MSG.apply(option, resolved));
-	}
+  /**
+   * update the current state value of a {@link LauncherOption}.
+   *
+   * <p>Before storing the value, performs any validation and transformation defined in the {@link
+   * LauncherOption} instance.
+   *
+   * @param option the {@link LauncherOption} to be associated with a value
+   * @param value the value to be associated
+   */
+  public static void setOption(LauncherOption option, String value) {
+    log.finer(ATTEMPT_SET_MSG.apply(option, value));
+    String resolved = option.getResolver().apply(value);
+    // note: using Object.equals() here breaks if both are null
+    if (value != resolved) log.finer(RESOLVED_MSG.apply(value, resolved));
+    validateOptionValue(option, value);
 
-	/**
-	 * Fetch any value currently associated with the given {@link LauncherOption},
-	 *
-	 * @param option the {@link LauncherOption} to be retrieved
-	 * @return the explicitly-set value associated with the given
-	 *         {@link LauncherOption}, or a suitable default if no explicit value is
-	 *         present
-	 */
-	public static String getOption(LauncherOption option) {
-		return instance.configMap.getOrDefault(option, option.getDefault());
-	}
+    instance.configMap.put(option, resolved);
+    option.recordOptionSet(LifecyclePhase.current);
+    log.fine(OPTION_SET_MSG.apply(option, resolved));
+  }
 
-	private static void validateOptionValue(LauncherOption option, String value) {
-		if (!option.getValidator().test(value)) {
-			throw new FXLauncherConfigException(
-					String.format("Cannot ingest invalid value '%s' into option '%s'. Not a valid value. Expected %s",
-							value, option, Validator.getExpected(option.getValidator())));
-		}
-	}
+  /**
+   * Fetch any value currently associated with the given {@link LauncherOption},
+   *
+   * @param option the {@link LauncherOption} to be retrieved
+   * @return the explicitly-set value associated with the given {@link LauncherOption}, or a
+   *     suitable default if no explicit value is present
+   */
+  public static String getOption(LauncherOption option) {
+    return instance.configMap.getOrDefault(option, option.getDefault());
+  }
 
-	private static final BiFunction<LauncherOption, String, String> ATTEMPT_SET_MSG = (opt, val) -> String
-			.format("Attempting to set LauncherOption.%s to value '%s'", opt, val);
-	private static final BinaryOperator<String> RESOLVED_MSG = (unresolved, resolved) -> String
-			.format("Input '%s' resolved to '%s'", unresolved, resolved);
-	private static final BiFunction<LauncherOption, String, String> OPTION_SET_MSG = (opt, val) -> String
-			.format("Successfully set option '%s' to '%s'", opt, val);
+  private static void validateOptionValue(LauncherOption option, String value) {
+    if (!option.getValidator().test(value)) {
+      throw new FXLauncherConfigException(
+          String.format(
+              "Cannot ingest invalid value '%s' into option '%s'. Not a valid value. Expected %s",
+              value, option, Validator.getExpected(option.getValidator())));
+    }
+  }
+
+  private static final BiFunction<LauncherOption, String, String> ATTEMPT_SET_MSG =
+      (opt, val) -> String.format("Attempting to set LauncherOption.%s to value '%s'", opt, val);
+  private static final BinaryOperator<String> RESOLVED_MSG =
+      (unresolved, resolved) -> String.format("Input '%s' resolved to '%s'", unresolved, resolved);
+  private static final BiFunction<LauncherOption, String, String> OPTION_SET_MSG =
+      (opt, val) -> String.format("Successfully set option '%s' to '%s'", opt, val);
 }

--- a/src/main/java/fxlauncher/config/LauncherOption.java
+++ b/src/main/java/fxlauncher/config/LauncherOption.java
@@ -6,6 +6,7 @@ import static fxlauncher.model.lifecycle.LifecyclePhase.STARTUP;
 import static java.util.logging.Logger.getLogger;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toSet;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -27,233 +28,244 @@ import fxlauncher.model.lifecycle.LifecyclePhase;
  * @author idavis1
  */
 public enum LauncherOption {
-	CONFIG_FILE("config-file", true, Defaults.CONFIG_FILE, null, null),
-	OVERRIDES_URL("overrides-url", true, Defaults.NONE, null, Validator.URL),
-	MANIFEST_URL("manifest-url", true, Defaults.NONE, null, Validator.URL),
-	MANIFEST_FILE("manifest-file", true, Defaults.MANIFEST_FILE, null, null),
-	ARTIFACTS_REPO_URL("artifacts-repo-url", true, Defaults.NONE, null, Validator.URL),
-	CACHE_DIR("cache-dir", true, Defaults.CACHE_DIR, Resolver.CACHE_DIR, null),
-	LOG_FILE("log-file", true, Defaults.LOG_FILE, null, null),
-	IGNORE_SSL("ignore-ssl", false, Defaults.BOOL_FALSE, null, Validator.BOOL),
-	OFFLINE("offline", false, Defaults.BOOL_FALSE, null, Validator.BOOL),
-	STOP_ON_UPDATE_ERROR("stop-on-update-error", false, Defaults.BOOL_TRUE, null, Validator.BOOL),
-	ACCEPT_DOWNGRADE("accept-downgrade", false, Defaults.BOOL_FALSE, null, Validator.BOOL),
-	PRELOAD_NATIVE_LIBS("preload-native-libs", true, Defaults.NONE, null, null),
-	HEADLESS("headless", false, Defaults.BOOL_FALSE, null, Validator.BOOL),
-	WHATS_NEW_URL("whats-new-url", true, Defaults.NONE, null, Validator.URL),
-	LINGERING_UPDATE_SCREEN("lingering-update-screen", false, Defaults.BOOL_TRUE, null, Validator.BOOL),;
+  CONFIG_FILE("config-file", true, Defaults.CONFIG_FILE, null, null),
+  OVERRIDES_URL("overrides-url", true, Defaults.NONE, null, Validator.URL),
+  MANIFEST_URL("manifest-url", true, Defaults.NONE, null, Validator.URL),
+  MANIFEST_FILE("manifest-file", true, Defaults.MANIFEST_FILE, null, null),
+  ARTIFACTS_REPO_URL("artifacts-repo-url", true, Defaults.NONE, null, Validator.URL),
+  CACHE_DIR("cache-dir", true, Defaults.CACHE_DIR, Resolver.CACHE_DIR, null),
+  LOG_FILE("log-file", true, Defaults.LOG_FILE, null, null),
+  IGNORE_SSL("ignore-ssl", false, Defaults.BOOL_FALSE, Resolver.BOOL, Validator.BOOL),
+  OFFLINE("offline", false, Defaults.BOOL_FALSE, Resolver.BOOL, Validator.BOOL),
+  STOP_ON_UPDATE_ERROR(
+      "stop-on-update-error", false, Defaults.BOOL_TRUE, Resolver.BOOL, Validator.BOOL),
+  ACCEPT_DOWNGRADE("accept-downgrade", false, Defaults.BOOL_FALSE, Resolver.BOOL, Validator.BOOL),
+  PRELOAD_NATIVE_LIBS("preload-native-libs", true, Defaults.NONE, null, null),
+  HEADLESS("headless", false, Defaults.BOOL_FALSE, Resolver.BOOL, Validator.BOOL),
+  WHATS_NEW_URL("whats-new-url", true, Defaults.NONE, null, Validator.URL),
+  LINGERING_UPDATE_SCREEN(
+      "lingering-update-screen", false, Defaults.BOOL_TRUE, Resolver.BOOL, Validator.BOOL),
+  ;
 
-	private final static Logger log = getLogger(LauncherOption.class.getName());
+  private static final Logger log = getLogger(LauncherOption.class.getName());
 
-	// the string that should be used in a command-line argument or properties file
-	// to set this option
-	private final String label;
-	private final Pattern pattern;
+  // the string that should be used in a command-line argument or properties file
+  // to set this option
+  private final String label;
+  private final Pattern pattern;
 
-	// used to identify when a value has not been explicitly set by a user
-	LifecyclePhase lastSetDuring = STARTUP;
+  // used to identify when a value has not been explicitly set by a user
+  LifecyclePhase lastSetDuring = STARTUP;
 
-	private final String defaultVal;
+  private final String defaultVal;
 
-	private final Resolver resolver;
-	private final Validator validator;
+  private final Resolver resolver;
+  private final Validator validator;
 
-	/**
-	 * Retrieve the set of labels for all {@link LauncherOption} instances
-	 *
-	 * @return the set of labels
-	 */
-	public static Set<String> labels() {
-		return Arrays.asList(values()).stream().map(LauncherOption::getLabel).collect(Collectors.toSet());
-	}
+  /**
+   * Convenience method for returning the values as a {@link Set} (which is iterable)
+   *
+   * @return all {@link LauncherOption} instances as a {@link Set}.
+   */
+  public static Set<LauncherOption> getValueSet() {
+    return Arrays.asList(values()).stream().collect(toSet());
+  }
 
-	/**
-	 * Get a subset of options that satisfy some predicate
-	 *
-	 * @param predicate The predicate that determines which enum instances should be
-	 *                  included in the subset
-	 * @return the set of {@link LauncherOption} objects that satisfy the predicate
-	 *         (return true);
-	 */
-	private static Set<LauncherOption> getSubset(Predicate<LauncherOption> predicate) {
-		return Stream.of(values()).filter(predicate).collect(toCollection(() -> EnumSet.noneOf(LauncherOption.class)));
-	}
+  /**
+   * Retrieve the set of labels for all {@link LauncherOption} instances
+   *
+   * @return the set of labels
+   */
+  public static Set<String> labels() {
+    return Arrays.asList(values())
+        .stream()
+        .map(LauncherOption::getLabel)
+        .collect(Collectors.toSet());
+  }
 
-	/**
-	 * Get all those options that were most recently set from a properties file
-	 *
-	 * @return the set of {@link LauncherOption} objects
-	 */
-	public static Set<LauncherOption> getProps() {
-		return getSubset(LauncherOption::isProp);
-	}
+  /**
+   * Get a subset of options that satisfy some predicate
+   *
+   * @param predicate The predicate that determines which enum instances should be included in the
+   *     subset
+   * @return the set of {@link LauncherOption} objects that satisfy the predicate (return true);
+   */
+  private static Set<LauncherOption> getSubset(Predicate<LauncherOption> predicate) {
+    return Stream.of(values())
+        .filter(predicate)
+        .collect(toCollection(() -> EnumSet.noneOf(LauncherOption.class)));
+  }
 
-	/**
-	 * Get all those options that were most recently set from a command-line
-	 * argument
-	 *
-	 * @return the set of {@link LauncherOption} objects
-	 */
-	public static Set<LauncherOption> getArgs() {
-		return getSubset(LauncherOption::isArg);
-	}
+  /**
+   * Get all those options that were most recently set from a properties file
+   *
+   * @return the set of {@link LauncherOption} objects
+   */
+  public static Set<LauncherOption> getProps() {
+    return getSubset(LauncherOption::isProp);
+  }
 
-	/**
-	 * Get all those options that have not been explicitly set
-	 *
-	 * @return the set of {@link LauncherOption} objects
-	 */
-	public static Set<LauncherOption> getUnset() {
-		return getSubset(LauncherOption::isUnset);
-	}
+  /**
+   * Get all those options that were most recently set from a command-line argument
+   *
+   * @return the set of {@link LauncherOption} objects
+   */
+  public static Set<LauncherOption> getArgs() {
+    return getSubset(LauncherOption::isArg);
+  }
 
-	/**
-	 * Get all those options that have been explicitly set
-	 *
-	 * @return the set of {@link LauncherOption} objects
-	 */
-	public static Set<LauncherOption> getSet() {
-		return getSubset(LauncherOption::isSet);
-	}
+  /**
+   * Get all those options that have not been explicitly set
+   *
+   * @return the set of {@link LauncherOption} objects
+   */
+  public static Set<LauncherOption> getUnset() {
+    return getSubset(LauncherOption::isUnset);
+  }
 
-	/**
-	 * Convenience method allows an action to be performed on all LauncherOption
-	 * intances.
-	 *
-	 * @param action the action to be performed
-	 */
-	public static void forEach(Consumer<LauncherOption> action) {
-		for (LauncherOption opt : values())
-			action.accept(opt);
-	}
+  /**
+   * Get all those options that have been explicitly set
+   *
+   * @return the set of {@link LauncherOption} objects
+   */
+  public static Set<LauncherOption> getSet() {
+    return getSubset(LauncherOption::isSet);
+  }
 
-	private LauncherOption(String label, boolean hasArg, String defaultVal, Resolver resolver, Validator validator) {
-		this.label = label;
-		this.defaultVal = defaultVal;
+  /**
+   * Convenience method allows an action to be performed on all LauncherOption intances.
+   *
+   * @param action the action to be performed
+   */
+  public static void forEach(Consumer<LauncherOption> action) {
+    for (LauncherOption opt : values()) action.accept(opt);
+  }
 
-		String patternString = Stream.of("--", label, hasArg ? "=(.+)" : "").collect(joining());
-		pattern = Pattern.compile(patternString);
+  private LauncherOption(
+      String label, boolean hasArg, String defaultVal, Resolver resolver, Validator validator) {
+    this.label = label;
+    this.defaultVal = defaultVal;
 
-		this.resolver = resolver == null ? Resolver.DEFAULT : resolver;
-		this.validator = validator == null ? Validator.DEFAULT : validator;
-	}
+    String patternString = Stream.of("--", label, hasArg ? "=(.+)" : "").collect(joining());
+    pattern = Pattern.compile(patternString);
 
-	/**
-	 * get the label from this {@link LauncherOption} instance
-	 *
-	 * @return the label for a particular {@link LauncherOption}
-	 */
-	public String getLabel() {
-		return this.label;
-	}
+    this.resolver = resolver == null ? Resolver.DEFAULT : resolver;
+    this.validator = validator == null ? Validator.DEFAULT : validator;
+  }
 
-	/**
-	 * get the default value from this {@link LauncherOption}
-	 *
-	 * @return the default value for a particular {@link LauncherOption}
-	 */
-	public String getDefault() {
-		return this.defaultVal;
-	}
+  /**
+   * get the label from this {@link LauncherOption} instance
+   *
+   * @return the label for a particular {@link LauncherOption}
+   */
+  public String getLabel() {
+    return this.label;
+  }
 
-	/**
-	 * check whether this @{link LauncherOption} was last set from a properties file
-	 *
-	 * @return {@code true} if this {@link LauncherOption} was last set from a
-	 *         properties file, {@code false} otherwise
-	 */
-	public boolean isProp() {
-		return lastSetDuring == LOAD_EMBEDDED_CONFIG;
-	}
+  /**
+   * get the default value from this {@link LauncherOption}
+   *
+   * @return the default value for a particular {@link LauncherOption}
+   */
+  public String getDefault() {
+    return this.defaultVal;
+  }
 
-	/**
-	 * check whether this {@link LauncherOption} was last set from a command-line
-	 * argument
-	 *
-	 * @return {@code true} if this {@link LauncherOption} was last set from a
-	 *         command-line argument, {@code false} otherwise
-	 */
-	public boolean isArg() {
-		return lastSetDuring == PARSE_CLI_ARGS;
-	}
+  /**
+   * check whether this @{link LauncherOption} was last set from a properties file
+   *
+   * @return {@code true} if this {@link LauncherOption} was last set from a properties file, {@code
+   *     false} otherwise
+   */
+  public boolean isProp() {
+    return lastSetDuring == LOAD_EMBEDDED_CONFIG;
+  }
 
-	/**
-	 * check whether this {@link LauncherOption} has been explicitly set
-	 *
-	 * @return {@code true} if this {@link LauncherOption} has ever been explicitly
-	 *         set, {@code false} otherwise
-	 */
-	public boolean isSet() {
-		return lastSetDuring != STARTUP;
-	}
+  /**
+   * check whether this {@link LauncherOption} was last set from a command-line argument
+   *
+   * @return {@code true} if this {@link LauncherOption} was last set from a command-line argument,
+   *     {@code false} otherwise
+   */
+  public boolean isArg() {
+    return lastSetDuring == PARSE_CLI_ARGS;
+  }
 
-	/**
-	 * check whether this {@link LauncherOption} has not been explicitly set
-	 *
-	 * @return {@code false} if this {@link LauncherOption} has ever been explicitly
-	 *         set, {@code true} otherwise
-	 */
-	public boolean isUnset() {
-		return !this.isSet();
-	}
+  /**
+   * check whether this {@link LauncherOption} has been explicitly set
+   *
+   * @return {@code true} if this {@link LauncherOption} has ever been explicitly set, {@code false}
+   *     otherwise
+   */
+  public boolean isSet() {
+    return lastSetDuring != STARTUP;
+  }
 
-	/**
-	 * get a Matcher object that can be used to match a String to a
-	 * {@link LauncherOption} used to resolve properties and command-line arguments
-	 *
-	 * @param arg
-	 * @return a {@link Matcher} created from the {@link LauncherOption}'s label and
-	 *         the string to be matched.
-	 */
-	public Matcher getMatcher(String arg) {
-		return pattern.matcher(arg);
-	}
+  /**
+   * check whether this {@link LauncherOption} has not been explicitly set
+   *
+   * @return {@code false} if this {@link LauncherOption} has ever been explicitly set, {@code true}
+   *     otherwise
+   */
+  public boolean isUnset() {
+    return !this.isSet();
+  }
 
-	/**
-	 * get the {@link Resolver} registered to a {@link LauncherOption}
-	 *
-	 * @return the {@link Resolver}
-	 */
-	Resolver getResolver() {
-		return resolver;
-	}
+  /**
+   * get a Matcher object that can be used to match a String to a {@link LauncherOption} used to
+   * resolve properties and command-line arguments
+   *
+   * @param arg an argument that might match one of the {@link LauncherOption} instances.
+   * @return a {@link Matcher} created from the {@link LauncherOption}'s label and the string to be
+   *     matched.
+   */
+  public Matcher getMatcher(String arg) {
+    return pattern.matcher(arg);
+  }
 
-	/**
-	 * get the {@link Validator} registered to a {@link LauncherOption}
-	 *
-	 * @return
-	 */
-	Validator getValidator() {
-		return validator;
-	}
+  /**
+   * get the {@link Resolver} registered to a {@link LauncherOption}
+   *
+   * @return the {@link Resolver}
+   */
+  Resolver getResolver() {
+    return resolver;
+  }
 
-	/**
-	 * make a note of the most recent time this {@link LauncherOption} was set
-	 *
-	 * @param phase
-	 */
-	void recordOptionSet(LifecyclePhase phase) {
-		log.finer(String.format("Option '%s' set during phase '%s'", this, phase));
-		this.lastSetDuring = phase;
-	}
+  /**
+   * get the {@link Validator} registered to a {@link LauncherOption}
+   *
+   * @return the validator for this {@link LauncherOption} instance
+   */
+  Validator getValidator() {
+    return validator;
+  }
 
-	/**
-	 * The set of default values for FxLauncher {@link LauncherOption} objects
-	 *
-	 * @implNote these are included in an inner class rather than as standard
-	 *           'private static final String' constants because Java does not
-	 *           provide access to static objects during execution of the enum
-	 *           constructors.
-	 *
-	 * @author idavis1
-	 */
-	private static class Defaults {
-		private static final String CONFIG_FILE = "launcher.properties";
-		private static final String LOG_FILE = System.getProperty("java.io.tmpdir") + "fxlauncher.log";
-		private static final String MANIFEST_FILE = "app.xml";
-		private static final String CACHE_DIR = Paths.get(".").toString();
-		private static final String BOOL_FALSE = Boolean.FALSE.toString();
-		private static final String BOOL_TRUE = Boolean.TRUE.toString();
-		private static final String NONE = null;
-	}
+  /**
+   * make a note of the most recent time this {@link LauncherOption} was set
+   *
+   * @param phase the {@link LifecyclePhase} during which this option was last set
+   */
+  void recordOptionSet(LifecyclePhase phase) {
+    log.finer(String.format("Option '%s' set during phase '%s'", this, phase));
+    this.lastSetDuring = phase;
+  }
+
+  /**
+   * The set of default values for FxLauncher {@link LauncherOption} objects
+   *
+   * @implNote these are included in an inner class rather than as standard 'private static final
+   *     String' constants because Java does not provide access to static objects during execution
+   *     of the enum constructors.
+   * @author idavis1
+   */
+  private static class Defaults {
+    private static final String CONFIG_FILE = "launcher.properties";
+    private static final String LOG_FILE = System.getProperty("java.io.tmpdir") + "fxlauncher.log";
+    private static final String MANIFEST_FILE = "app.xml";
+    private static final String CACHE_DIR = Paths.get(".").toString();
+    private static final String BOOL_FALSE = Boolean.FALSE.toString();
+    private static final String BOOL_TRUE = Boolean.TRUE.toString();
+    private static final String NONE = null;
+  }
 }

--- a/src/main/java/fxlauncher/config/Resolver.java
+++ b/src/main/java/fxlauncher/config/Resolver.java
@@ -9,33 +9,37 @@ import fxlauncher.model.OS;
 @FunctionalInterface
 /**
  * Resolver performs a transformation on a String
- * 
- * example: {@link LauncherOption} instance {@link CACHE_DIR} can accept
- * two sentinel values, ALLUSERS and USERLIB, which should be resolved to
- * OS-specific appropriate paths when accessed
- * 
+ *
+ * <p>example: {@link LauncherOption} instance {@link CACHE_DIR} can accept two sentinel values,
+ * ALLUSERS and USERLIB, which should be resolved to OS-specific appropriate paths when accessed
+ *
  * @author idavis1
  */
-public interface Resolver extends UnaryOperator<String>{
-	
-	static final Logger log = Logger.getLogger(Resolver.class.getName());
+public interface Resolver extends UnaryOperator<String> {
 
-	public static Resolver DEFAULT = unresolved -> unresolved;
-	
-	public static final Resolver CACHE_DIR = unresolved -> {
-		if(unresolved == null) return unresolved;
-		log.finer("Attempting resolution of option CACHE_DIR");
-		log.finer(String.format("Unresolved value: '%s'", unresolved));
-		String resolved = unresolved; // assume no change, then check if change is necessary
+  static final Logger log = Logger.getLogger(Resolver.class.getName());
 
-		for(GenericPathLabel genericPath : GenericPathLabel.values()) {
-			if(unresolved.startsWith(genericPath.name())) {
-				String trimmed = unresolved.replace(genericPath.name() + "/", "");
-				resolved = OS.current.getGenericPath(genericPath).resolve(trimmed).toString();
-			}
-		}
-		
-		log.finer(String.format("Returning resolved value of CACHE_DIR: '%s'", unresolved));
-		return resolved;	
-	};
+  public static Resolver DEFAULT = unresolved -> unresolved;
+
+  public static Resolver BOOL =
+      unresolved ->
+          unresolved == null || unresolved.trim().equals("") ? Boolean.TRUE.toString() : unresolved;
+
+  public static final Resolver CACHE_DIR =
+      unresolved -> {
+        if (unresolved == null) return unresolved;
+        log.finer("Attempting resolution of option CACHE_DIR");
+        log.finer(String.format("Unresolved value: '%s'", unresolved));
+        String resolved = unresolved; // assume no change, then check if change is necessary
+
+        for (GenericPathLabel genericPath : GenericPathLabel.values()) {
+          if (unresolved.startsWith(genericPath.name())) {
+            String trimmed = unresolved.replace(genericPath.name() + "/", "");
+            resolved = OS.current.getGenericPath(genericPath).resolve(trimmed).toString();
+          }
+        }
+
+        log.finer(String.format("Returning resolved value of CACHE_DIR: '%s'", unresolved));
+        return resolved;
+      };
 }

--- a/src/main/java/fxlauncher/config/Validator.java
+++ b/src/main/java/fxlauncher/config/Validator.java
@@ -11,31 +11,39 @@ import java.util.regex.Pattern;
  */
 public interface Validator extends Predicate<String> {
 
-	static public String getExpected(Validator validator) {
-		if (validator == Validator.BOOL)
-			return "boolean";
-		if (validator == Validator.URL)
-			return "URL";
-		return "String";
-	}
+  public static String getExpected(Validator validator) {
+    if (validator == Validator.BOOL) return "boolean";
+    if (validator == Validator.URL) return "URL";
+    return "String";
+  }
 
-	// OWASP-supplied URL pattern-matching regexp
-	static final String URL_REGEX = "^((((https?|ftps?|gopher|telnet|nntp)://)|(mailto:|news:))"
-			+ "(%[0-9A-Fa-f]{2}|[-()_.!~*';/?:@&=+$,A-Za-z0-9])+)" + "([).!';/?:,][[:blank:]])?$";
+  // OWASP-supplied URL pattern-matching regexp
+  static final String URL_REGEX =
+      "^((((https?|ftps?|gopher|telnet|nntp)://)|(mailto:|news:))"
+          + "(%[0-9A-Fa-f]{2}|[-()_.!~*';/?:@&=+$,A-Za-z0-9])+)"
+          + "([).!';/?:,][[:blank:]])?$";
 
-	static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
+  static final Pattern URL_PATTERN = Pattern.compile(URL_REGEX);
 
-	public static final Validator DEFAULT = string -> true;
+  public static final Validator DEFAULT = string -> (string != null && !string.trim().equals(""));
 
-	public static final Validator BOOL = string -> {
-		Logger.getLogger(Validator.BOOL.getClass().getName())
-				.finer(String.format("validating as boolean: '%s'", string));
-		return string == null ? false : string.equalsIgnoreCase("true") || string.equalsIgnoreCase("false");
-	};
+  public static final Validator BOOL =
+      string -> {
+        Logger.getLogger(Validator.BOOL.getClass().getName())
+            .finer(String.format("validating as boolean: '%s'", string == null ? "null" : string));
+        // assume flag-behavior for boolean... if it's explicitly set by name-only, it's true
+        return (string == null || string.trim().equals(""))
+            ? true
+            : string.equalsIgnoreCase("true") || string.equalsIgnoreCase("false");
+      };
 
-	public static final Validator URL = string -> {
-		Logger.getLogger(Validator.URL.getClass().getName()).finer(String.format("validating as URL: '%s'", string));
+  public static final Validator URL =
+      string -> {
+        Logger.getLogger(Validator.URL.getClass().getName())
+            .finer(String.format("validating as URL: '%s'", string));
 
-		return string == null ? false : URL_PATTERN.matcher(string).matches();
-	};
+        return (string == null || string.equals(""))
+            ? false
+            : URL_PATTERN.matcher(string).matches();
+      };
 }

--- a/src/main/java/fxlauncher/config/ingest/ConfigurationIngester.java
+++ b/src/main/java/fxlauncher/config/ingest/ConfigurationIngester.java
@@ -1,15 +1,19 @@
 package fxlauncher.config.ingest;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
 
+import fxlauncher.config.LauncherConfig;
+import fxlauncher.config.LauncherOption;
 import fxlauncher.downstream.DownstreamParameters;
 
 /**
  * Base class for all classes that read in a source of FxLauncher configuration
- * data. Subclasses are expected to implement the
- * {@code _ingestParams()) method and
- * return the set of ingested options that do not match any {@link
- * LauncherOption} value.
+ * data. Subclasses are expected to implement the {@code _ingestParams()} method
+ * and return the set of ingested options that do not match any
+ * {@link LauncherOption} value.
  *
  * @author idavis1
  */
@@ -22,6 +26,10 @@ public abstract class ConfigurationIngester {
 	protected boolean overwriteArgs = true;
 	protected DownstreamParameters downstreamParams = defaultDownstreamParams;
 
+	// using a functional interface here allows this class (and subclasses) to be
+	// tested in isolation from LauncherConfig (we can use a mocked implementation)
+	protected BiConsumer<LauncherOption, String> ingestOp = LauncherConfig::setOption;
+
 	// set for all new instances
 	public static void setDefaultDownstreamParams(DownstreamParameters downstreamParams) {
 		ConfigurationIngester.defaultDownstreamParams = downstreamParams;
@@ -32,7 +40,7 @@ public abstract class ConfigurationIngester {
 	 * {@link DownstreamParameters} object.
 	 */
 	public void ingest() {
-		List<String> leftovers = _ingestParams();
+		List<String> leftovers = Optional.ofNullable(_ingest()).orElse(new ArrayList<>());
 		leftovers.forEach(arg -> downstreamParams.merge(arg, overwriteArgs));
 	}
 
@@ -46,5 +54,5 @@ public abstract class ConfigurationIngester {
 	 *
 	 * @return a list of ingested options not used by FxLauncher itself
 	 */
-	protected abstract List<String> _ingestParams();
+	protected abstract List<String> _ingest();
 }

--- a/src/main/java/fxlauncher/config/ingest/PropertiesFileIngester.java
+++ b/src/main/java/fxlauncher/config/ingest/PropertiesFileIngester.java
@@ -1,7 +1,11 @@
 package fxlauncher.config.ingest;
 
+import static java.util.logging.Logger.getLogger;
+import static java.util.stream.Collectors.toList;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -11,9 +15,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
-import fxlauncher.config.LauncherConfig;
 import fxlauncher.config.LauncherOption;
 import fxlauncher.tools.io.ClasspathResourceFetcher;
 
@@ -21,133 +23,110 @@ import fxlauncher.tools.io.ClasspathResourceFetcher;
  * Implementation of {@link ConfigurationIngester} that reads values in from a
  * Java properties file.
  *
- * @implNote using {@link Supplier<String>} to provide the configuration
- *           filename allows resolution of the value when {@code _ingest()} is
- *           invoked, rather than at or before execution of the constructor.
- *           This is useful when another {@link ConfigurationIngester} changes
- *           the configuration state after this object is constructed, but
- *           before its {@code _ingest()} method runs. We always want to run
- *           {@code _ingest()} based on the current state at the time of
- *           execution. In the case where this value is not expected to be
- *           changed, a String can be provided and this class will construct the
- *           appropriate Supplier for it.
- *
  * @author idavis1
  *
  */
 public class PropertiesFileIngester extends ConfigurationIngester {
 
-	private static final Logger log = Logger.getLogger(PropertiesFileIngester.class.getName());
+    private static final Logger log = getLogger(PropertiesFileIngester.class.getName());
 
-	private final Properties props = new Properties();
+    private final Properties props = new Properties();
 
-	private Supplier<String> resourceNameSupplier = () -> LauncherOption.CONFIG_FILE.getDefault();
+    /*
+     * using Supplier<String> to provide the configuration filename allows
+     * resolution of the value when _ingest() is invoked, rather than at or before
+     * execution of the constructor. This is useful when another
+     * ConfigurationIngester changes the configuration state after this object is
+     * constructed, but before its _ingest() method runs. We always want to run
+     * _ingest() based on the current state at the time of execution. In the case
+     * where this value is not expected to be changed, a String can be provided and
+     * this class will construct the appropriate Supplier for it.
+     */
+    private Supplier<String> resourceNameSupplier = () -> LauncherOption.CONFIG_FILE.getDefault();
 
-	public PropertiesFileIngester() {
-		super();
+    // Using a functional interface here allows Mockito to inject a mock
+    private Function<String, ClasspathResourceFetcher> fetcherFactory = ClasspathResourceFetcher::new;
+
+    public PropertiesFileIngester(String resourceName) {
+	super();
+	this.resourceNameSupplier = () -> resourceName;
+    }
+
+    public PropertiesFileIngester(Supplier<String> resourceNameSupplier) {
+	super();
+	this.resourceNameSupplier = resourceNameSupplier;
+    }
+
+    // invoked by superclass -- ingest properties from the named resource
+    @Override
+    protected List<String> _ingest() {
+	loadEmbeddedProps(resourceNameSupplier.get());
+	Map<Object, Object> propsMap = new HashMap<>(props);
+	propsMap.forEach((key, value) -> matchAndExtract(key, value));
+	return props.entrySet().stream().map(PropertiesFileIngester::formatProperty).collect(toList());
+    }
+
+    private void loadEmbeddedProps(String resourceName) {
+	log.info(NOTIFY_MSG.apply(resourceName));
+	Optional<InputStream> fetched = fetcherFactory.apply(resourceName).fetch();
+
+	if (fetched.isPresent()) {
+	    log.info(FOUND_MSG.apply(resourceName));
+	    try {
+		props.load(fetched.get());
+	    } catch (IOException | IllegalArgumentException iae) {
+		log.warning(INVALID_MSG.apply(resourceName));
+		iae.printStackTrace();
+	    }
+	} else {
+	    log.info(NOT_FOUND_MSG.apply(resourceName));
+	}
+    }
+
+    private void matchAndExtract(Object keyObj, Object valueObj) {
+	String key = keyObj.toString();
+	String value = valueObj.toString();
+
+	log.finer(INGEST_PROP_MSG.apply(key, value));
+	boolean found = false;
+	for (LauncherOption opt : LauncherOption.values()) {
+	    if (key.equals(opt.getLabel())) {
+		log.finer(MATCHED_OPT_MSG.apply(key, opt.toString()));
+		ingestOp.accept(opt, value);
+		props.remove(key);
+		return;
+	    }
 	}
 
-	public PropertiesFileIngester(String resourceName) {
-		super();
-		this.resourceNameSupplier = () -> resourceName;
-	}
+	log.finer(UNMATCHED_OPT_MSG.apply(key));
+    }
 
-	public PropertiesFileIngester(Supplier<String> resourceNameSupplier) {
-		super();
-		this.resourceNameSupplier = resourceNameSupplier;
-	}
+    private static String formatProperty(Map.Entry<Object, Object> property) {
+	return (property.getValue() == null || property.getValue().toString().trim().equals(""))
+		? UNNAMED_PROP_FMT.apply(property)
+		: NAMED_PROP_FMT.apply(property);
+    }
 
-	/**
-	 * Fluent interface for setting the {@code resourceName} member.
-	 *
-	 * @param resourceName the static name of a resource containing configuration
-	 *                     settings as Java properties
-	 * @return this PropertiesFileIngester object, so that further operations can be
-	 *         performed on it
-	 */
-	public PropertiesFileIngester forPropertyFile(String resourceName) {
-		this.resourceNameSupplier = () -> resourceName;
-		return this;
-	}
+    // just giving convenient names to some simple but cumbersome String formatting
+    // logic to improve readability above this comment
+    private static final UnaryOperator<String> NOTIFY_MSG = resourceName -> String
+	    .format("Looking for embedded properties resource: %s", resourceName);
+    private static final UnaryOperator<String> FOUND_MSG = resourceName -> String
+	    .format("Found embedded properties file %s", resourceName);
+    private static final UnaryOperator<String> INVALID_MSG = resourceName -> String
+	    .format("Failed to load embedded properties file '%s'. Check file format/syntax", resourceName);
+    private static final UnaryOperator<String> NOT_FOUND_MSG = resourceName -> String
+	    .format("No embedded properties file '%s' found", resourceName);
+    private static final BinaryOperator<String> INGEST_PROP_MSG = (key, value) -> String
+	    .format("Attempting to property with key=%s and value=%s...", key, value);
+    private static final BinaryOperator<String> MATCHED_OPT_MSG = (key, opt) -> String
+	    .format("Matched property key '%s' to LauncherOption '%s'...", key, opt);
+    private static final UnaryOperator<String> UNMATCHED_OPT_MSG = key -> String
+	    .format("No LauncherOption found to match property key '%s'. Passing along to downstream app", key);
 
-	/**
-	 * Fluent interface for setting the {@code resourceName} member.
-	 *
-	 * @param resourceName a {@link Supplier} of the name of a resource containing
-	 *                     configuration settings as Java properties
-	 * @return this PropertiesFileIngester object, so that further operations can be
-	 *         performed on it
-	 */
-	public PropertiesFileIngester forPropertyFile(Supplier<String> resourceNameSupplier) {
-		this.resourceNameSupplier = resourceNameSupplier;
-		return this;
-	}
-
-	// invoked by superclass -- ingest properties from the named resource
-	@Override
-	protected List<String> _ingestParams() {
-		loadEmbeddedProps(resourceNameSupplier.get());
-		props.forEach(this::matchAndExtract);
-		return props.entrySet().stream().map(PropertiesFileIngester::formatProperty).collect(Collectors.toList());
-	}
-
-	private void loadEmbeddedProps(String resourceName) {
-		log.fine(NOTIFY_MSG.apply(resourceName));
-		Optional<InputStream> fetched = new ClasspathResourceFetcher(resourceName).fetch();
-
-		if (fetched.isPresent()) {
-			log.info(FOUND_MSG.apply(resourceName));
-			try {
-				props.load(fetched.get());
-			} catch (IOException e) {
-				log.warning(INVALID_MSG.apply(resourceName));
-				e.printStackTrace();
-			}
-		}
-
-		log.info(NOT_FOUND_MSG);
-	}
-
-	private void matchAndExtract(Object keyObj, Object valueObj) {
-		String key = keyObj.toString();
-		String value = valueObj.toString();
-
-		log.finer(INGEST_PROP_MSG.apply(key, value));
-		for (LauncherOption opt : LauncherOption.values()) {
-			if (key.equals(opt.getLabel())) {
-				log.finer(MATCHED_OPT_MSG.apply(key, opt.toString()));
-				LauncherConfig.setOption(opt, value);
-				props.remove(keyObj);
-			}
-			return;
-		}
-		log.finer(UNMATCHED_OPT_MSG.apply(key));
-	}
-
-	private static String formatProperty(Map.Entry<Object, Object> property) {
-		return (property.getValue() == null) ? UNNAMED_PROP_FMT.apply(property) : NAMED_PROP_FMT.apply(property);
-	}
-
-	// just giving convenient names to some simple but cumbersome String formatting
-	// logic to improve readability above this comment
-	private static final UnaryOperator<String> NOTIFY_MSG = resourceName -> String
-			.format("Importing embedded properties resource: %s", resourceName);
-	private static final UnaryOperator<String> FOUND_MSG = resourceName -> String
-			.format("Found embedded properties file %s", resourceName);
-	private static final UnaryOperator<String> INVALID_MSG = resourceName -> String
-			.format("Failed to load embedded properties file '%s'. Check file format/syntax", resourceName);
-	private static final String NOT_FOUND_MSG = "No embedded properties file found";
-
-	private static final BinaryOperator<String> INGEST_PROP_MSG = (key, value) -> String
-			.format("Attempting to property with key=%s and value=%s...", key, value);
-	private static final BinaryOperator<String> MATCHED_OPT_MSG = (key, opt) -> String
-			.format("Matched property key '%s' to LauncherOption '%s'...", key, opt);
-	private static final UnaryOperator<String> UNMATCHED_OPT_MSG = key -> String
-			.format("No LauncherOption found to match property key '%s'. Passing along to downstream app", key);
-
-	private static final Function<Map.Entry<Object, Object>, String> NAMED_PROP_FMT = prop -> String.format("--%s=%s",
-			prop.getKey().toString(), prop.getValue().toString());
-	private static final Function<Map.Entry<Object, Object>, String> UNNAMED_PROP_FMT = prop -> String.format("--%s",
-			prop.getKey().toString());
+    private static final Function<Map.Entry<Object, Object>, String> NAMED_PROP_FMT = prop -> String.format("--%s=%s",
+	    prop.getKey().toString(), prop.getValue().toString());
+    private static final Function<Map.Entry<Object, Object>, String> UNNAMED_PROP_FMT = prop -> String.format("--%s",
+	    prop.getKey().toString());
 
 }

--- a/src/main/java/fxlauncher/downstream/DownstreamParameters.java
+++ b/src/main/java/fxlauncher/downstream/DownstreamParameters.java
@@ -2,7 +2,7 @@ package fxlauncher.downstream;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,98 +25,103 @@ import javafx.application.Application;
  */
 public class DownstreamParameters extends Application.Parameters {
 
-	private static final Pattern NAMED_PATTERN = Pattern.compile("--(?<key>.\\+)=(?<value>.\\+)");
+    public DownstreamParameters() {
+	super();
+    }
 
-	// use Set to simply enforce uniqueness
-	private static Set<String> rawParams = new HashSet<>();
-	private static Set<String> unnamedParams = new HashSet<>();
-	private static Map<String, String> namedParams = new HashMap<>();
+    private static final Pattern NAMED_PATTERN = Pattern.compile("--(?<key>.+)=(?<value>.+)");
 
-	/**
-	 * Return the set of raw arguments
-	 */
-	@Override
-	public List<String> getRaw() {
-		return new ArrayList<>(rawParams);
+    // use Set to simply enforce uniqueness
+    // using LinkedHashSet preserves insertion order
+    private Set<String> rawParams = new LinkedHashSet<>();
+    private Set<String> unnamedParams = new LinkedHashSet<>();
+    private Map<String, String> namedParams = new HashMap<>();
+
+    /**
+     * Return the set of raw arguments
+     */
+    @Override
+    public List<String> getRaw() {
+	return new ArrayList<>(rawParams);
+    }
+
+    /**
+     * Return the set of unnamed arguments (i.e. those not of the format
+     * '--key=value')
+     */
+    @Override
+    public List<String> getUnnamed() {
+	return new ArrayList<>(unnamedParams);
+    }
+
+    /**
+     * Return the set of named arguments (i.e. those of the format '--key=value')
+     */
+    @Override
+    public Map<String, String> getNamed() {
+	return namedParams;
+    }
+
+    /**
+     * Return the set of arguments as a String array This is useful when trying to
+     * launch the downstream program via a {@code main()} method.
+     *
+     * @return the set of arguments as an array
+     */
+    public String[] getArgs() {
+	return rawParams.stream().toArray(String[]::new);
+    }
+
+    /**
+     * Add the argument to the set of downstream parameters, unless it is already
+     * present in the set
+     *
+     * Useful when ingesting a manifest to avoid overwriting any
+     * {@link fxlauncher.config.LauncherConfig} options that were explicitly set by
+     * command-line args, embedded configuration files, or remote overrides
+     *
+     * @param string the argument to be merged into the set of Parameters
+     */
+    public void mergeIfNotPresent(String string) {
+	merge(string, false);
+    }
+
+    /**
+     * Add the argument to the set of downstream parameters, overwriting any
+     * pre-existing value
+     *
+     * Useful when ingesting initial configuration data from command-line args,
+     * embedded configuration files, and remote overrides, where precedence is set
+     * by order and each should override the previous sets of configuration.
+     *
+     * @param string the argument to be merged into the set of Parameters
+     */
+    public void mergeOverwriting(String string) {
+	merge(string, true);
+    }
+
+    /**
+     * Generic merge method that hands both overwriting and non-overwriting cases
+     *
+     * note that overwriting only applies to named parameters uniqueness of
+     * non-named parameters and CLI arguments is ensured by the use of a Set
+     * internally.
+     *
+     * @param string    the argument to be merged into the set of Parameters
+     * @param overwrite a boolean indicating whether existing parameters should be
+     *                  overwritten
+     */
+    public void merge(String string, boolean overwrite) {
+	Matcher matcher = NAMED_PATTERN.matcher(string);
+	if (matcher.find()) {
+	    String key = matcher.group("key");
+	    String value = matcher.group("value");
+	    if (overwrite || !namedParams.containsKey(key)) {
+		namedParams.put(key, value);
+	    }
+	} else {
+	    unnamedParams.add(string);
 	}
-
-	/**
-	 * Return the set of unnamed arguments (i.e. those not of the format
-	 * '--key=value')
-	 */
-	@Override
-	public List<String> getUnnamed() {
-		return new ArrayList<>(unnamedParams);
-	}
-
-	/**
-	 * Return the set of named arguments (i.e. those of the format '--key=value')
-	 */
-	@Override
-	public Map<String, String> getNamed() {
-		return namedParams;
-	}
-
-	/**
-	 * Return the set of arguments as a String array This is useful when trying to
-	 * launch the downstream program via a {@code main()} method.
-	 *
-	 * @return the set of arguments as an array
-	 */
-	public String[] getArgs() {
-		return rawParams.parallelStream().toArray(String[]::new);
-	}
-
-	/**
-	 * Add the argument to the set of downstream parameters, unless it is already
-	 * present in the set
-	 *
-	 * Useful when ingesting a manifest to avoid overwriting any
-	 * {@link LauncherConfig} options that were explicitly set by command-line args,
-	 * embedded configuration files, or remote overrides
-	 *
-	 * @param string the argument to be merged into the set of Parameters
-	 */
-	public void mergeIfNotPresent(String string) {
-		merge(string, false);
-	}
-
-	/**
-	 * Add the argument to the set of downstream parameters, overwriting any
-	 * pre-existing value
-	 *
-	 * Useful when ingesting initial configuration data from command-line args,
-	 * embedded configuration files, and remote overrides, where precedence is set
-	 * by order and each should override the previous sets of configuration.
-	 *
-	 * @param string the argument to be merged into the set of Parameters
-	 */
-	public void mergeOverwriting(String string) {
-		merge(string, true);
-	}
-
-	/**
-	 * Generic merge method that hands both overwriting and non-overwriting cases
-	 *
-	 * note that overwriting only applies to named parameters uniqueness of
-	 * non-named parameters and CLI arguments is ensured by the use of a Set
-	 * internally.
-	 *
-	 * @param string    the argument to be merged into the set of Parameters
-	 * @param overwrite a boolean indicating whether existing parameters should be
-	 *                  overwritten
-	 */
-	public void merge(String string, boolean overwrite) {
-		Matcher matcher = NAMED_PATTERN.matcher(string);
-		if (matcher.find()) {
-			String key = matcher.group("key");
-			String value = matcher.group("value");
-			if (overwrite || !namedParams.containsKey(key)) {
-				namedParams.put(key, value);
-			}
-		} else {
-			unnamedParams.add(string);
-		}
-		rawParams.add(string);
-	}
+	rawParams.add(string);
+    }
 }

--- a/src/main/java/fxlauncher/model/OS.java
+++ b/src/main/java/fxlauncher/model/OS.java
@@ -9,66 +9,73 @@ import java.nio.file.Paths;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.logging.Logger;
 
 /**
- * Represents an operating-system supported by FxLauncher
- * Also provides resolution of OS-specific generic paths USERLIB and ALLUSERS
- * @author idavis1
+ * Represents an operating-system supported by FxLauncher Also provides resolution of OS-specific
+ * generic paths USERLIB and ALLUSERS
  *
+ * @author idavis1
  */
 public enum OS {
-	WIN,
-	MAC,
-	LINUX,
-	OTHER,
-	;
-	
-	private final static Logger log = getLogger(OS.class.getName());
-	public static final OS current;
-	
-	private final Path home = Paths.get(System.getProperty("user.home"));
-	private final Map<GenericPathLabel, Path> pathMap = new EnumMap<GenericPathLabel, Path>(GenericPathLabel.class);
-	
-	private OS() {
-		Path userLibPath;
-		Path allUsersPath;
-		
-		switch (this.name().toLowerCase()) {
-			case "mac":
-				userLibPath = home.resolve("Library").resolve("Application Support");
-				allUsersPath = Paths.get("/Library/Application Support");
-				break;
-			case "win":
-				userLibPath = home.resolve("AppData").resolve("Local");
-				allUsersPath = Paths.get(Optional.ofNullable(System.getenv("ALLUSERSPROFILE")).orElse(""));
-				break;
-			default:
-				userLibPath = home;
-				allUsersPath = Paths.get("/usr/local/share");
-				break;
-		}
-		pathMap.put(USERLIB, userLibPath);
-		pathMap.put(ALLUSERS, allUsersPath);
-	}
-	
-	/**
-	 * Fetch the generic path for a supported sentinel value and the OS represented by this instance
-	 * @param label the sentinel value, as an enum
-	 * @return the {@link Path} object for the provided sentinel value.
-	 */
-	public Path getGenericPath(GenericPathLabel label) {
-		return pathMap.get(label);
-	}
-	
-	// initializer runs at class-load time
-	static {
-		String os = System.getProperty("os.name", "generic").toLowerCase();
-		
-		if ((os.contains("mac")) || (os.contains("darwin"))) current = MAC;
-		else if (os.contains("win")) current = WIN;
-		else if (os.contains("nux")) current = LINUX;
-		else current = OTHER;
-		log.finer(String.format("Current operating system is: %s", MAC));
-	}
+  WIN,
+  MAC,
+  LINUX,
+  OTHER,
+  ;
+
+  private static final Logger log = getLogger(OS.class.getName());
+  public static final OS current;
+
+  private final Path home = Paths.get(System.getProperty("user.home"));
+
+  /* Using Suppliers to resolve these paths at get-time, rather than at constructor-time
+   * means that any changes in the ALLUSERSPROFILE environment variable after this class
+   * is loaded is reflected in the returned result. That's probably not super useful in
+   * real-use scenarios, but it makes testing on a non-Windows platform much easier.
+   */
+  private final Map<GenericPathLabel, Supplier<Path>> genericPaths =
+      new EnumMap<GenericPathLabel, Supplier<Path>>(GenericPathLabel.class);
+
+  private OS() {
+
+    switch (this.name().toLowerCase()) {
+      case "mac":
+        genericPaths.put(USERLIB, () -> home.resolve("Library").resolve("Application Support"));
+        genericPaths.put(ALLUSERS, () -> Paths.get("/Library/Application Support"));
+        break;
+      case "win":
+        genericPaths.put(USERLIB, () -> home.resolve("AppData").resolve("Local"));
+        genericPaths.put(
+            ALLUSERS,
+            () -> Paths.get(Optional.ofNullable(System.getenv("ALLUSERSPROFILE")).orElse("")));
+        break;
+      default:
+        genericPaths.put(USERLIB, () -> home);
+        genericPaths.put(ALLUSERS, () -> Paths.get("/usr/local/share"));
+        break;
+    }
+  }
+
+  /**
+   * Fetch the generic path for a supported sentinel value and the OS represented by this instance
+   *
+   * @param label the sentinel value, as an enum
+   * @return the {@link Path} object for the provided sentinel value.
+   */
+  public Path getGenericPath(GenericPathLabel label) {
+    return genericPaths.get(label).get();
+  }
+
+  // initializer runs at class-load time
+  static {
+    String os = System.getProperty("os.name", "generic").toLowerCase();
+
+    if ((os.contains("mac")) || (os.contains("darwin"))) current = MAC;
+    else if (os.contains("win")) current = WIN;
+    else if (os.contains("nux")) current = LINUX;
+    else current = OTHER;
+    log.finer(String.format("Current operating system is: %s", MAC));
+  }
 }

--- a/src/main/java/fxlauncher/old/Launcher.java
+++ b/src/main/java/fxlauncher/old/Launcher.java
@@ -1,6 +1,18 @@
 package fxlauncher.old;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import com.sun.javafx.application.PlatformImpl;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
@@ -13,280 +25,273 @@ import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URI;
-import java.nio.file.Path;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ServiceLoader;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.concurrent.CountDownLatch;
-
 @SuppressWarnings("unchecked")
 public class Launcher extends Application {
-    private static final Logger log = Logger.getLogger("Launcher");
+	private static final Logger log = Logger.getLogger("Launcher");
 
-    private Application app;
-    private Stage primaryStage;
-    private Stage stage;
-    private UIProvider uiProvider;
-    private StackPane root;
+	private Application app;
+	private Stage primaryStage;
+	private Stage stage;
+	private UIProvider uiProvider;
+	private StackPane root;
 
-    private final AbstractLauncher superLauncher = new AbstractLauncher<Application>() {
-        @Override
-        protected Parameters getParameters() {
-            return Launcher.this.getParameters();
-        }
+	private final AbstractLauncher superLauncher = new AbstractLauncher<Application>() {
+		@Override
+		protected Parameters getParameters() {
+			return Launcher.this.getParameters();
+		}
 
-        @Override
-        protected void updateProgress(double progress) {
-            Platform.runLater(() -> uiProvider.updateProgress(progress));
-        }
+		@Override
+		protected void updateProgress(double progress) {
+			Platform.runLater(() -> uiProvider.updateProgress(progress));
+		}
 
-        @Override
-        protected void createApplication(Class<Application> appClass) {
-            runAndWait(() ->
-            {
-                try {
-                    if (Application.class.isAssignableFrom(appClass)) {
-                        app = appClass.newInstance();
-                    } else {
-                        throw new IllegalArgumentException(String.format("Supplied appClass %s was not a subclass of javafx.application.Application!", appClass));
-                    }
-                } catch (Throwable t) {
-                    reportError("Error creating app class", t);
-                }
-            });
-        }
+		@Override
+		protected void createApplication(Class<Application> appClass) {
+			runAndWait(() -> {
+				try {
+					if (Application.class.isAssignableFrom(appClass)) {
+						app = appClass.newInstance();
+					} else {
+						throw new IllegalArgumentException(String.format(
+								"Supplied appClass %s was not a subclass of javafx.application.Application!",
+								appClass));
+					}
+				} catch (Throwable t) {
+					reportError("Error creating app class", t);
+				}
+			});
+		}
 
-        @Override
-        protected void reportError(String title, Throwable error) {
-            log.log(Level.WARNING, title, error);
+		@Override
+		protected void reportError(String title, Throwable error) {
+			log.log(Level.WARNING, title, error);
 
-            Platform.runLater(() ->
-            {
-                Alert alert = new Alert(Alert.AlertType.ERROR);
-                alert.setTitle(title);
-                alert.setHeaderText(String.format("%s\ncheck the logfile 'fxlauncher.log, usually in the %s directory", title, System.getProperty("java.io.tmpdir")));
+			Platform.runLater(() -> {
+				Alert alert = new Alert(Alert.AlertType.ERROR);
+				alert.setTitle(title);
+				alert.setHeaderText(String.format("%s\ncheck the logfile 'fxlauncher.log, usually in the %s directory",
+						title, System.getProperty("java.io.tmpdir")));
 //            alert.setHeaderText(title+"\nCheck the logfile usually in the "+System.getProperty("java.io.tmpdir") + "directory");
-                alert.getDialogPane().setPrefWidth(600);
+				alert.getDialogPane().setPrefWidth(600);
 
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                PrintWriter writer = new PrintWriter(out);
-                error.printStackTrace(writer);
-                writer.close();
-                TextArea text = new TextArea(out.toString());
-                alert.getDialogPane().setContent(text);
+				ByteArrayOutputStream out = new ByteArrayOutputStream();
+				PrintWriter writer = new PrintWriter(out);
+				error.printStackTrace(writer);
+				writer.close();
+				TextArea text = new TextArea(out.toString());
+				alert.getDialogPane().setContent(text);
 
-                alert.showAndWait();
-                Platform.exit();
-            });
-        }
+				alert.showAndWait();
+				Platform.exit();
+			});
+		}
 
-        @Override
-        protected void setupClassLoader(ClassLoader classLoader) {
-            FXMLLoader.setDefaultClassLoader(classLoader);
-            Platform.runLater(() -> Thread.currentThread().setContextClassLoader(classLoader));
-        }
+		@Override
+		protected void setupClassLoader(ClassLoader classLoader) {
+			FXMLLoader.setDefaultClassLoader(classLoader);
+			Platform.runLater(() -> Thread.currentThread().setContextClassLoader(classLoader));
+		}
 
+	};
 
-    };
+	/**
+	 * Check if a new version is available and return the manifest for the new
+	 * version or null if no update.
+	 * <p>
+	 * Note that updates will only be detected if the application was actually
+	 * launched with FXLauncher.
+	 *
+	 * @return The manifest for the new version if available
+	 * @throws IOException if manifest not found
+	 */
+	public static FXManifest checkForUpdate() throws IOException {
+		// We might be called even when FXLauncher wasn't used to start the application
+		if (AbstractLauncher.manifest == null)
+			return null;
+		FXManifest manifest = FXManifest.load(URI.create(AbstractLauncher.manifest.uri + "/app.xml"));
+		return manifest.equals(AbstractLauncher.manifest) ? null : manifest;
+	}
 
-    /**
-     * Check if a new version is available and return the manifest for the new version or null if no update.
-     * <p>
-     * Note that updates will only be detected if the application was actually launched with FXLauncher.
-     *
-     * @return The manifest for the new version if available
-     */
-    public static FXManifest checkForUpdate() throws IOException {
-        // We might be called even when FXLauncher wasn't used to start the application
-        if (AbstractLauncher.manifest == null) return null;
-        FXManifest manifest = FXManifest.load(URI.create(AbstractLauncher.manifest.uri + "/app.xml"));
-        return manifest.equals(AbstractLauncher.manifest) ? null : manifest;
-    }
+	/**
+	 * Initialize the UI Provider by looking for an UIProvider inside the launcher
+	 * or fallback to the default UI.
+	 * <p>
+	 * A custom implementation must be embedded inside the launcher jar, and
+	 * /META-INF/services/fxlauncher.UIProvider must point to the new implementation
+	 * class.
+	 * <p>
+	 * You must do this manually/in your build right around the "embed manifest"
+	 * step.
+	 */
+	@Override
+	public void init() throws Exception {
+		Iterator<UIProvider> providers = ServiceLoader.load(UIProvider.class).iterator();
+		uiProvider = providers.hasNext() ? providers.next() : new DefaultUIProvider();
+	}
 
+	@Override
+	public void start(Stage primaryStage) throws Exception {
+		this.primaryStage = primaryStage;
+		stage = new Stage(StageStyle.UNDECORATED);
+		root = new StackPane();
+		final boolean[] filesUpdated = new boolean[1];
 
-    /**
-     * Initialize the UI Provider by looking for an UIProvider inside the launcher
-     * or fallback to the default UI.
-     * <p>
-     * A custom implementation must be embedded inside the launcher jar, and
-     * /META-INF/services/fxlauncher.UIProvider must point to the new implementation class.
-     * <p>
-     * You must do this manually/in your build right around the "embed manifest" step.
-     */
-    public void init() throws Exception {
-        Iterator<UIProvider> providers = ServiceLoader.load(UIProvider.class).iterator();
-        uiProvider = providers.hasNext() ? providers.next() : new DefaultUIProvider();
-    }
+		Scene scene = new Scene(root);
+		stage.setScene(scene);
 
-    public void start(Stage primaryStage) throws Exception {
-        this.primaryStage = primaryStage;
-        stage = new Stage(StageStyle.UNDECORATED);
-        root = new StackPane();
-        final boolean[] filesUpdated = new boolean[1];
+		superLauncher.setupLogFile();
+		superLauncher.checkSSLIgnoreflag();
+		this.uiProvider.init(stage);
+		root.getChildren().add(uiProvider.createLoader());
 
-        Scene scene = new Scene(root);
-        stage.setScene(scene);
+		stage.show();
 
-        superLauncher.setupLogFile();
-        superLauncher.checkSSLIgnoreflag();
-        this.uiProvider.init(stage);
-        root.getChildren().add(uiProvider.createLoader());
+		new Thread(() -> {
+			Thread.currentThread().setName("FXLauncher-Thread");
+			try {
+				superLauncher.updateManifest();
+				createUpdateWrapper();
+				filesUpdated[0] = superLauncher.syncFiles();
+			} catch (Exception ex) {
+				log.log(Level.WARNING, String.format("Error during %s phase", superLauncher.getPhase()), ex);
+				if (superLauncher.checkIgnoreUpdateErrorSetting()) {
+					superLauncher.reportError(String.format("Error during %s phase", superLauncher.getPhase()), ex);
+					System.exit(1);
+				}
+			}
 
-        stage.show();
+			try {
+				superLauncher.createApplicationEnvironment();
+				launchAppFromManifest(filesUpdated[0]);
+			} catch (Exception ex) {
+				superLauncher.reportError(String.format("Error during %s phase", superLauncher.getPhase()), ex);
+			}
 
-        new Thread(() -> {
-            Thread.currentThread().setName("FXLauncher-Thread");
-            try {
-                superLauncher.updateManifest();
-                createUpdateWrapper();
-                filesUpdated[0] = superLauncher.syncFiles();
-            } catch (Exception ex) {
-                log.log(Level.WARNING, String.format("Error during %s phase", superLauncher.getPhase()), ex);
-                if (superLauncher.checkIgnoreUpdateErrorSetting()) {
-                    superLauncher.reportError(String.format("Error during %s phase", superLauncher.getPhase()), ex);
-                    System.exit(1);
-                }
-            }
+		}).start();
+	}
 
-            try {
-                superLauncher.createApplicationEnvironment();
-                launchAppFromManifest(filesUpdated[0]);
-            } catch (Exception ex) {
-                superLauncher.reportError(String.format("Error during %s phase", superLauncher.getPhase()), ex);
-            }
+	private void launchAppFromManifest(boolean showWhatsnew) throws Exception {
+		superLauncher.setPhase("Application Environment Prepare");
 
-        }).start();
-    }
+		try {
+			initApplication();
+		} catch (Throwable ex) {
+			superLauncher.reportError("Error during app init", ex);
+		}
+		superLauncher.setPhase("Application Start");
+		log.info("Show whats new dialog? " + showWhatsnew);
 
-    private void launchAppFromManifest(boolean showWhatsnew) throws Exception {
-        superLauncher.setPhase("Application Environment Prepare");
+		runAndWait(() -> {
+			try {
+				if (showWhatsnew && superLauncher.getManifest().whatsNewPage != null)
+					showWhatsNewDialog(superLauncher.getManifest().whatsNewPage);
 
-        try {
-            initApplication();
-        } catch (Throwable ex) {
-            superLauncher.reportError("Error during app init", ex);
-        }
-        superLauncher.setPhase("Application Start");
-        log.info("Show whats new dialog? " + showWhatsnew);
+				// Lingering update screen will close when primary stage is shown
+				if (superLauncher.getManifest().lingeringUpdateScreen) {
+					primaryStage.showingProperty().addListener(observable -> {
+						if (stage.isShowing())
+							stage.close();
+					});
+				} else {
+					stage.close();
+				}
 
-        runAndWait(() ->
-        {
-            try {
-                if (showWhatsnew && superLauncher.getManifest().whatsNewPage != null)
-                    showWhatsNewDialog(superLauncher.getManifest().whatsNewPage);
+				startApplication();
+			} catch (Throwable ex) {
+				superLauncher.reportError("Failed to start application", ex);
+			}
+		});
+	}
 
-                // Lingering update screen will close when primary stage is shown
-                if (superLauncher.getManifest().lingeringUpdateScreen) {
-                    primaryStage.showingProperty().addListener(observable -> {
-                        if (stage.isShowing())
-                            stage.close();
-                    });
-                } else {
-                    stage.close();
-                }
+	private void showWhatsNewDialog(String whatsNewURL) {
+		WebView view = new WebView();
+		view.getEngine().load(whatsNewURL);
+		Alert alert = new Alert(Alert.AlertType.INFORMATION);
+		alert.setTitle("What's new");
+		alert.setHeaderText("New in this update");
+		alert.getDialogPane().setContent(view);
+		alert.showAndWait();
+	}
 
-                startApplication();
-            } catch (Throwable ex) {
-                superLauncher.reportError("Failed to start application", ex);
-            }
-        });
-    }
+	public static void main(String[] args) {
+		launch(args);
+	}
 
-    private void showWhatsNewDialog(String whatsNewURL) {
-        WebView view = new WebView();
-        view.getEngine().load(whatsNewURL);
-        Alert alert = new Alert(Alert.AlertType.INFORMATION);
-        alert.setTitle("What's new");
-        alert.setHeaderText("New in this update");
-        alert.getDialogPane().setContent(view);
-        alert.showAndWait();
-    }
+	private void createUpdateWrapper() {
+		superLauncher.setPhase("Update Wrapper Creation");
 
-    public static void main(String[] args) {
-        launch(args);
-    }
+		Platform.runLater(() -> {
+			Parent updater = uiProvider.createUpdater(superLauncher.getManifest());
+			root.getChildren().clear();
+			root.getChildren().add(updater);
+		});
+	}
 
-    private void createUpdateWrapper() {
-        superLauncher.setPhase("Update Wrapper Creation");
+	@Override
+	public void stop() throws Exception {
+		if (app != null)
+			app.stop();
+	}
 
-        Platform.runLater(() ->
-        {
-            Parent updater = uiProvider.createUpdater(superLauncher.getManifest());
-            root.getChildren().clear();
-            root.getChildren().add(updater);
-        });
-    }
+	private void initApplication() throws Exception {
+		if (app != null) {
+			app.init();
+		}
+	}
 
-    public void stop() throws Exception {
-        if (app != null)
-            app.stop();
-    }
+	private void startApplication() throws Exception {
+		if (app != null) {
+			final LauncherParams params = new LauncherParams(getParameters(), superLauncher.getManifest());
+			app.getParameters().getNamed().putAll(params.getNamed());
+			app.getParameters().getRaw().addAll(params.getRaw());
+			app.getParameters().getUnnamed().addAll(params.getUnnamed());
 
-    private void initApplication() throws Exception {
-        if (app != null) {
-            app.init();
-        }
-    }
+			PlatformImpl.setApplicationName(app.getClass());
+			superLauncher.setPhase("Application Init");
+			app.start(primaryStage);
+		} else {
+			// Start any executable jar (i.E. Spring Boot);
+			String firstFile = superLauncher.getManifest().files.get(0).file;
+			log.info(String.format("No app class defined, starting first file (%s)", firstFile));
+			Path cacheDir = superLauncher.getManifest().resolveCacheDir(getParameters().getNamed());
+			String command = String.format("java -jar %s/%s", cacheDir.toAbsolutePath(), firstFile);
+			log.info(String.format("Execute command '%s'", command));
+			Runtime.getRuntime().exec(command);
+		}
+	}
 
-    private void startApplication() throws Exception {
-        if (app != null) {
-            final LauncherParams params = new LauncherParams(getParameters(), superLauncher.getManifest());
-            app.getParameters().getNamed().putAll(params.getNamed());
-            app.getParameters().getRaw().addAll(params.getRaw());
-            app.getParameters().getUnnamed().addAll(params.getUnnamed());
+	/**
+	 * Runs the specified {@link Runnable} on the JavaFX application thread and
+	 * waits for completion.
+	 *
+	 * @param action the {@link Runnable} to run
+	 * @throws NullPointerException if {@code action} is {@code null}
+	 */
+	void runAndWait(Runnable action) {
+		if (action == null)
+			throw new NullPointerException("action");
 
-            PlatformImpl.setApplicationName(app.getClass());
-            superLauncher.setPhase("Application Init");
-            app.start(primaryStage);
-        } else {
-            // Start any executable jar (i.E. Spring Boot);
-            String firstFile = superLauncher.getManifest().files.get(0).file;
-            log.info(String.format("No app class defined, starting first file (%s)", firstFile));
-            Path cacheDir = superLauncher.getManifest().resolveCacheDir(getParameters().getNamed());
-            String command = String.format("java -jar %s/%s", cacheDir.toAbsolutePath(), firstFile);
-            log.info(String.format("Execute command '%s'", command));
-            Runtime.getRuntime().exec(command);
-        }
-    }
+		// run synchronously on JavaFX thread
+		if (Platform.isFxApplicationThread()) {
+			action.run();
+			return;
+		}
 
+		// queue on JavaFX thread and wait for completion
+		final CountDownLatch doneLatch = new CountDownLatch(1);
+		Platform.runLater(() -> {
+			try {
+				action.run();
+			} finally {
+				doneLatch.countDown();
+			}
+		});
 
-    /**
-     * Runs the specified {@link Runnable} on the
-     * JavaFX application thread and waits for completion.
-     *
-     * @param action the {@link Runnable} to run
-     * @throws NullPointerException if {@code action} is {@code null}
-     */
-    void runAndWait(Runnable action) {
-        if (action == null)
-            throw new NullPointerException("action");
-
-        // run synchronously on JavaFX thread
-        if (Platform.isFxApplicationThread()) {
-            action.run();
-            return;
-        }
-
-        // queue on JavaFX thread and wait for completion
-        final CountDownLatch doneLatch = new CountDownLatch(1);
-        Platform.runLater(() -> {
-            try {
-                action.run();
-            } finally {
-                doneLatch.countDown();
-            }
-        });
-
-        try {
-            doneLatch.await();
-        } catch (InterruptedException e) {
-            // ignore exception
-        }
-    }
+		try {
+			doneLatch.await();
+		} catch (InterruptedException e) {
+			// ignore exception
+		}
+	}
 }

--- a/src/main/java/fxlauncher/tools/io/ClasspathResourceFetcher.java
+++ b/src/main/java/fxlauncher/tools/io/ClasspathResourceFetcher.java
@@ -4,8 +4,8 @@ import java.io.InputStream;
 import java.util.Optional;
 import java.util.logging.Logger;
 
+import fxlauncher.LauncherMain;
 import fxlauncher.except.FXLauncherException;
-import fxlauncher.old.Launcher;
 
 /**
  * Implementation of {@link FileFetcher} that retrieves a resource from the
@@ -29,6 +29,6 @@ public class ClasspathResourceFetcher implements FileFetcher {
 	@Override
 	public Optional<InputStream> fetch() throws FXLauncherException {
 		log.fine("Fetching resource " + resourceName);
-		return Optional.ofNullable(Launcher.class.getResourceAsStream(resourceName));
+		return Optional.ofNullable(LauncherMain.class.getResourceAsStream(resourceName));
 	}
 }

--- a/src/main/java/fxlauncher/tools/io/InputStreamTools.java
+++ b/src/main/java/fxlauncher/tools/io/InputStreamTools.java
@@ -1,0 +1,16 @@
+package fxlauncher.tools.io;
+
+import static java.util.stream.Collectors.joining;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+public class InputStreamTools {
+
+	public static String readInputStream(InputStream inputStream) {
+		return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()
+				.collect(joining("\n"));
+	}
+}

--- a/src/test/java/fxlauncher/config/LauncherConfigTest.java
+++ b/src/test/java/fxlauncher/config/LauncherConfigTest.java
@@ -1,0 +1,69 @@
+package fxlauncher.config;
+
+import static fxlauncher.config.LauncherOption.CACHE_DIR;
+import static fxlauncher.testutils.ReflectionTools.setCurrentOS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import fxlauncher.except.FXLauncherConfigException;
+import fxlauncher.model.GenericPathLabel;
+import fxlauncher.model.OS;
+
+@DisplayName("LauncherConfigTest")
+public class LauncherConfigTest extends LauncherConfigTestHarness {
+
+  @DisplayName("Simple set-and-retrieve tests...")
+  @ParameterizedTest(name = "LauncherConfig correctly retrieves {0} as \"{1}\"")
+  @MethodSource("fxlauncher.config.LauncherConfigTestHarness#getTestSetOptionArgs")
+  void testSetOption(LauncherOption opt, String value) {
+    // before set
+    assertFalse(opt.isSet());
+    assertEquals(LauncherConfig.getOption(opt), opt.getDefault());
+
+    LauncherConfig.setOption(opt, value);
+    String actual = LauncherConfig.getOption(opt);
+
+    // after set
+    assertTrue(opt.isSet());
+    assertEquals(value, actual);
+  }
+
+  @DisplayName("CACHE_DIR resolver resolves correctly for...")
+  @ParameterizedTest(name = "OS {0} and Generic Path {1}")
+  @MethodSource("fxlauncher.config.LauncherConfigTestHarness#cacheDirResolverTestArgs")
+  void testCacheDirResolver(OS os, GenericPathLabel label) throws Exception {
+    setCurrentOS(os);
+    String unresolved = cacheDirResolutionMap.get(os).get(label)[0];
+    String resolved = cacheDirResolutionMap.get(os).get(label)[1];
+
+    LauncherConfig.setOption(CACHE_DIR, unresolved);
+    assertEquals(resolved, LauncherConfig.getOption(CACHE_DIR));
+  }
+
+  @DisplayName("During validation...")
+  @ParameterizedTest(name = "{0} rejects invalid input value \"{1}\"")
+  @MethodSource("fxlauncher.config.LauncherConfigTestHarness#getInvalidInputTestArgs")
+  void validationTests(LauncherOption opt, String input) {
+
+    assertThrows(FXLauncherConfigException.class, () -> LauncherConfig.setOption(opt, input));
+  }
+
+  @DisplayName("Boolean option...")
+  @ParameterizedTest(name = "{0} correctly interprets edge-case \"{1}\" as true")
+  @MethodSource("fxlauncher.config.LauncherConfigTestHarness#getBooleanEdgeCaseArgs")
+  void booleanEdgeCaseTest(LauncherOption opt, String value) {
+    value = value.equals("null") ? null : value;
+    LauncherConfig.setOption(opt, value);
+    String actual = LauncherConfig.getOption(opt);
+
+    // after set
+    assertTrue(opt.isSet());
+    assertEquals("true", actual);
+  }
+}

--- a/src/test/java/fxlauncher/config/LauncherConfigTestHarness.java
+++ b/src/test/java/fxlauncher/config/LauncherConfigTestHarness.java
@@ -1,0 +1,259 @@
+package fxlauncher.config;
+
+import static fxlauncher.config.LauncherOption.ACCEPT_DOWNGRADE;
+import static fxlauncher.config.LauncherOption.ARTIFACTS_REPO_URL;
+import static fxlauncher.config.LauncherOption.CACHE_DIR;
+import static fxlauncher.config.LauncherOption.CONFIG_FILE;
+import static fxlauncher.config.LauncherOption.HEADLESS;
+import static fxlauncher.config.LauncherOption.IGNORE_SSL;
+import static fxlauncher.config.LauncherOption.LINGERING_UPDATE_SCREEN;
+import static fxlauncher.config.LauncherOption.LOG_FILE;
+import static fxlauncher.config.LauncherOption.MANIFEST_FILE;
+import static fxlauncher.config.LauncherOption.MANIFEST_URL;
+import static fxlauncher.config.LauncherOption.OFFLINE;
+import static fxlauncher.config.LauncherOption.OVERRIDES_URL;
+import static fxlauncher.config.LauncherOption.PRELOAD_NATIVE_LIBS;
+import static fxlauncher.config.LauncherOption.STOP_ON_UPDATE_ERROR;
+import static fxlauncher.config.LauncherOption.WHATS_NEW_URL;
+import static fxlauncher.model.GenericPathLabel.ALLUSERS;
+import static fxlauncher.model.GenericPathLabel.USERLIB;
+import static fxlauncher.model.OS.LINUX;
+import static fxlauncher.model.OS.MAC;
+import static fxlauncher.model.OS.OTHER;
+import static fxlauncher.model.OS.WIN;
+import static fxlauncher.model.lifecycle.LifecyclePhase.LOAD_EMBEDDED_CONFIG;
+import static fxlauncher.model.lifecycle.LifecyclePhase.STARTUP;
+import static fxlauncher.testutils.CollectionTools.asArray;
+import static fxlauncher.testutils.CollectionTools.asSet;
+import static fxlauncher.testutils.CollectionTools.generateSet;
+import static fxlauncher.testutils.LoggingTools.initTestLog;
+import static fxlauncher.testutils.ReflectionTools.setCurrentOS;
+import static java.util.Collections.emptySet;
+import static java.util.logging.Logger.getLogger;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
+
+import fxlauncher.model.GenericPathLabel;
+import fxlauncher.model.OS;
+import fxlauncher.model.lifecycle.LifecyclePhase;
+
+public class LauncherConfigTestHarness {
+
+  protected static final OS startingOS = OS.current;
+
+  protected static final Logger log =
+      initTestLog(getLogger(LauncherConfigTestHarness.class.getName()));
+
+  @BeforeEach
+  void setupSuite() {
+    // setting the LifecyclePhase to something other than "STARTUP" ensures the
+    // Set/Unset properties of each LauncherOption instance work correctly
+    LifecyclePhase.setCurrent(LOAD_EMBEDDED_CONFIG);
+    LauncherOption.forEach(opt -> opt.recordOptionSet(STARTUP));
+    LauncherConfig.restoreDefaults();
+  }
+
+  @AfterEach
+  void restoreStartingOS() throws Exception {
+    setCurrentOS(startingOS);
+  }
+
+  @SuppressWarnings("serial")
+  protected static final Map<LauncherOption, Set<String>> validValuesMap =
+      new EnumMap<LauncherOption, Set<String>>(LauncherOption.class) {
+        {
+          put(CONFIG_FILE, asSet("non-default.launcher.properties"));
+          put(OVERRIDES_URL, asSet("http://some.url.for/overrides"));
+          put(MANIFEST_URL, asSet("http://some.url.for/a-manifest"));
+          put(MANIFEST_FILE, asSet("non-default.app.xml"));
+          put(ARTIFACTS_REPO_URL, asSet("https://some.url.for/app-artifacts"));
+          put(CACHE_DIR, asSet("./non-default/home/directory"));
+          put(LOG_FILE, asSet("./non-default/home/directory/mylog"));
+          put(IGNORE_SSL, asSet("true", "false"));
+          put(OFFLINE, asSet("true", "false"));
+          put(STOP_ON_UPDATE_ERROR, asSet("true", "false"));
+          put(ACCEPT_DOWNGRADE, asSet("true", "false"));
+          put(PRELOAD_NATIVE_LIBS, asSet("some,libs,to,import"));
+          put(HEADLESS, asSet("true", "false"));
+          put(WHATS_NEW_URL, asSet("http://some.url.for/whats-new.file"));
+          put(LINGERING_UPDATE_SCREEN, asSet("true", "false"));
+        }
+      };
+
+  @SuppressWarnings("serial")
+  protected static final Map<OS, Map<GenericPathLabel, String[]>> cacheDirResolutionMap =
+      new EnumMap<OS, Map<GenericPathLabel, String[]>>(OS.class) {
+        {
+          put(
+              WIN,
+              new EnumMap<GenericPathLabel, String[]>(GenericPathLabel.class) {
+                {
+                  put(
+                      ALLUSERS,
+                      asArray(
+                          "ALLUSERS/TEST/PATH",
+                          WIN.getGenericPath(ALLUSERS).resolve("TEST").resolve("PATH").toString()));
+                  put(
+                      USERLIB,
+                      asArray(
+                          "USERLIB/TEST/PATH",
+                          WIN.getGenericPath(USERLIB).resolve("TEST").resolve("PATH").toString()));
+                }
+              });
+          put(
+              MAC,
+              new EnumMap<GenericPathLabel, String[]>(GenericPathLabel.class) {
+                {
+                  put(
+                      ALLUSERS,
+                      asArray(
+                          "ALLUSERS/TEST/PATH",
+                          MAC.getGenericPath(ALLUSERS).resolve("TEST").resolve("PATH").toString()));
+                  put(
+                      USERLIB,
+                      asArray(
+                          "USERLIB/TEST/PATH",
+                          MAC.getGenericPath(USERLIB).resolve("TEST").resolve("PATH").toString()));
+                  ;
+                }
+              });
+          put(
+              LINUX,
+              new EnumMap<GenericPathLabel, String[]>(GenericPathLabel.class) {
+                {
+                  put(
+                      ALLUSERS,
+                      asArray(
+                          "ALLUSERS/TEST/PATH",
+                          LINUX
+                              .getGenericPath(ALLUSERS)
+                              .resolve("TEST")
+                              .resolve("PATH")
+                              .toString()));
+                  put(
+                      USERLIB,
+                      asArray(
+                          "USERLIB/TEST/PATH",
+                          LINUX
+                              .getGenericPath(USERLIB)
+                              .resolve("TEST")
+                              .resolve("PATH")
+                              .toString()));
+                }
+              });
+          put(
+              OTHER,
+              new EnumMap<GenericPathLabel, String[]>(GenericPathLabel.class) {
+                {
+                  put(
+                      ALLUSERS,
+                      asArray(
+                          "ALLUSERS/TEST/PATH",
+                          OTHER
+                              .getGenericPath(ALLUSERS)
+                              .resolve("TEST")
+                              .resolve("PATH")
+                              .toString()));
+                  put(
+                      USERLIB,
+                      asArray(
+                          "USERLIB/TEST/PATH",
+                          OTHER
+                              .getGenericPath(USERLIB)
+                              .resolve("TEST")
+                              .resolve("PATH")
+                              .toString()));
+                }
+              });
+        }
+      };
+
+  private static final Set<String> NOT_A_URL_SET =
+      generateSet("", null, "not-a-url", "fakeScheme://some.domain/and/path?query=none&query=none");
+
+  private static final Set<String> BLANK_SET = generateSet("", null);
+
+  // treating null and the empty string as implicitly true
+  private static final Set<String> NOT_A_BOOL_SET =
+      generateSet("https://this.isnt/a/bool", "Scooby-Doo");
+
+  @SuppressWarnings("serial")
+  protected static final Map<LauncherOption, Set<String>> invalidValuesMap =
+      new EnumMap<LauncherOption, Set<String>>(LauncherOption.class) {
+        {
+          put(CONFIG_FILE, BLANK_SET);
+          put(OVERRIDES_URL, NOT_A_URL_SET);
+          put(MANIFEST_URL, NOT_A_URL_SET);
+          put(MANIFEST_FILE, BLANK_SET);
+          put(ARTIFACTS_REPO_URL, NOT_A_URL_SET);
+          put(CACHE_DIR, BLANK_SET);
+          put(LOG_FILE, BLANK_SET);
+          put(IGNORE_SSL, NOT_A_BOOL_SET);
+          put(OFFLINE, NOT_A_BOOL_SET);
+          put(STOP_ON_UPDATE_ERROR, NOT_A_BOOL_SET);
+          put(ACCEPT_DOWNGRADE, NOT_A_BOOL_SET);
+          put(PRELOAD_NATIVE_LIBS, BLANK_SET);
+          put(HEADLESS, NOT_A_BOOL_SET);
+          put(WHATS_NEW_URL, NOT_A_URL_SET);
+          put(LINGERING_UPDATE_SCREEN, NOT_A_BOOL_SET);
+        }
+      };
+
+  protected static List<Arguments> getTestSetOptionArgs() {
+    List<Arguments> argsList = new ArrayList<>();
+    LauncherOption.forEach(
+        opt -> {
+          validValuesMap
+              .getOrDefault(opt, emptySet())
+              .forEach(arg -> argsList.add(Arguments.of(opt, arg)));
+        });
+    return argsList;
+  }
+
+  // return cartesian product of Enum types OS and GenericPathLabel
+  protected static final List<Arguments> cacheDirResolverTestArgs() {
+    List<Arguments> argsList = new ArrayList<>();
+    for (OS os : OS.values()) {
+      for (GenericPathLabel path : GenericPathLabel.values()) {
+        argsList.add(Arguments.of(os, path));
+      }
+    }
+    return argsList;
+  }
+
+  protected static final List<Arguments> getInvalidInputTestArgs() {
+    List<Arguments> argsList = new ArrayList<>();
+
+    Stream.of(LauncherOption.values())
+        .forEach(
+            opt -> {
+              invalidValuesMap
+                  .getOrDefault(opt, emptySet())
+                  .forEach(arg -> argsList.add(Arguments.of(opt, arg)));
+            });
+    return argsList;
+  }
+
+  protected static final List<Arguments> getBooleanEdgeCaseArgs() {
+    List<Arguments> argsList = new ArrayList<>();
+    Stream.of(LauncherOption.values())
+        .filter(opt -> opt.getValidator() == Validator.BOOL)
+        .forEach(
+            opt -> {
+              argsList.add(Arguments.of(opt, ""));
+              argsList.add(Arguments.of(opt, " "));
+              argsList.add(Arguments.of(opt, "null"));
+            });
+    return argsList;
+  }
+}

--- a/src/test/java/fxlauncher/config/LauncherOptionTestHarness.java
+++ b/src/test/java/fxlauncher/config/LauncherOptionTestHarness.java
@@ -30,114 +30,120 @@ import fxlauncher.model.lifecycle.LifecyclePhase;
 
 public class LauncherOptionTestHarness {
 
-	@AfterEach
-	void restoreSetDuring() {
-		Stream.of(LauncherOption.values()).forEach(opt -> opt.recordOptionSet(STARTUP));
-	}
+  @AfterEach
+  void restoreSetDuring() {
+    Stream.of(LauncherOption.values()).forEach(opt -> opt.recordOptionSet(STARTUP));
+  }
 
-	protected static final Map<LauncherOption, String> labelMap = new EnumMap<LauncherOption, String>(
-			LauncherOption.class) {
-		{
-			put(CONFIG_FILE, "config-file");
-			put(OVERRIDES_URL, "overrides-url");
-			put(MANIFEST_URL, "manifest-url");
-			put(MANIFEST_FILE, "manifest-file");
-			put(ARTIFACTS_REPO_URL, "artifacts-repo-url");
-			put(CACHE_DIR, "cache-dir");
-			put(LOG_FILE, "log-file");
-			put(IGNORE_SSL, "ignore-ssl");
-			put(OFFLINE, "offline");
-			put(STOP_ON_UPDATE_ERROR, "stop-on-update-error");
-			put(ACCEPT_DOWNGRADE, "accept-downgrade");
-			put(PRELOAD_NATIVE_LIBS, "preload-native-libs");
-			put(HEADLESS, "headless");
-			put(WHATS_NEW_URL, "whats-new-url");
-			put(LINGERING_UPDATE_SCREEN, "lingering-update-screen");
-		}
-	};
+  protected static final Map<LauncherOption, String> labelMap =
+      new EnumMap<LauncherOption, String>(LauncherOption.class) {
+        {
+          put(CONFIG_FILE, "config-file");
+          put(OVERRIDES_URL, "overrides-url");
+          put(MANIFEST_URL, "manifest-url");
+          put(MANIFEST_FILE, "manifest-file");
+          put(ARTIFACTS_REPO_URL, "artifacts-repo-url");
+          put(CACHE_DIR, "cache-dir");
+          put(LOG_FILE, "log-file");
+          put(IGNORE_SSL, "ignore-ssl");
+          put(OFFLINE, "offline");
+          put(STOP_ON_UPDATE_ERROR, "stop-on-update-error");
+          put(ACCEPT_DOWNGRADE, "accept-downgrade");
+          put(PRELOAD_NATIVE_LIBS, "preload-native-libs");
+          put(HEADLESS, "headless");
+          put(WHATS_NEW_URL, "whats-new-url");
+          put(LINGERING_UPDATE_SCREEN, "lingering-update-screen");
+        }
+      };
 
-	protected static final Map<LauncherOption, String> defaultMap = new EnumMap<LauncherOption, String>(
-			LauncherOption.class) {
-		{
-			put(CONFIG_FILE, "launcher.properties");
-			put(OVERRIDES_URL, null);
-			put(MANIFEST_URL, null);
-			put(MANIFEST_FILE, "app.xml");
-			put(ARTIFACTS_REPO_URL, null);
-			put(CACHE_DIR, ".");
-			put(LOG_FILE, System.getProperty("java.io.tmpdir") + "fxlauncher.log");
-			put(IGNORE_SSL, Boolean.FALSE.toString());
-			put(OFFLINE, Boolean.FALSE.toString());
-			put(STOP_ON_UPDATE_ERROR, Boolean.TRUE.toString());
-			put(ACCEPT_DOWNGRADE, Boolean.FALSE.toString());
-			put(PRELOAD_NATIVE_LIBS, null);
-			put(HEADLESS, Boolean.FALSE.toString());
-			put(WHATS_NEW_URL, null);
-			put(LINGERING_UPDATE_SCREEN, Boolean.TRUE.toString());
-		}
-	};
+  protected static final Map<LauncherOption, String> defaultMap =
+      new EnumMap<LauncherOption, String>(LauncherOption.class) {
+        {
+          put(CONFIG_FILE, "launcher.properties");
+          put(OVERRIDES_URL, null);
+          put(MANIFEST_URL, null);
+          put(MANIFEST_FILE, "app.xml");
+          put(ARTIFACTS_REPO_URL, null);
+          put(CACHE_DIR, ".");
+          put(LOG_FILE, System.getProperty("java.io.tmpdir") + "fxlauncher.log");
+          put(IGNORE_SSL, Boolean.FALSE.toString());
+          put(OFFLINE, Boolean.FALSE.toString());
+          put(STOP_ON_UPDATE_ERROR, Boolean.TRUE.toString());
+          put(ACCEPT_DOWNGRADE, Boolean.FALSE.toString());
+          put(PRELOAD_NATIVE_LIBS, null);
+          put(HEADLESS, Boolean.FALSE.toString());
+          put(WHATS_NEW_URL, null);
+          put(LINGERING_UPDATE_SCREEN, Boolean.TRUE.toString());
+        }
+      };
 
-	protected static final Map<LauncherOption, String> matcherMap = new EnumMap<LauncherOption, String>(
-			LauncherOption.class) {
-		{
-			put(CONFIG_FILE, "--config-file=somefile");
-			put(OVERRIDES_URL, "--overrides-url=https://some-domain.com");
-			put(MANIFEST_URL, "--manifest-url=https://some-domain.com");
-			put(MANIFEST_FILE, "--manifest-file=somefile");
-			put(ARTIFACTS_REPO_URL, "--artifacts-repo-url=https://some-domain.com");
-			put(CACHE_DIR, "--cache-dir=somefile");
-			put(LOG_FILE, "--log-file=somefile");
-			put(IGNORE_SSL, "--ignore-ssl");
-			put(OFFLINE, "--offline");
-			put(STOP_ON_UPDATE_ERROR, "--stop-on-update-error");
-			put(ACCEPT_DOWNGRADE, "--accept-downgrade");
-			put(PRELOAD_NATIVE_LIBS, "--preload-native-libs=list,of,libs");
-			put(HEADLESS, "--headless");
-			put(WHATS_NEW_URL, "--whats-new-url=https://some-url");
-			put(LINGERING_UPDATE_SCREEN, "--lingering-update-screen");
-		}
-	};
+  protected static final Map<LauncherOption, String> matcherMap =
+      new EnumMap<LauncherOption, String>(LauncherOption.class) {
+        {
+          put(CONFIG_FILE, "--config-file=somefile");
+          put(OVERRIDES_URL, "--overrides-url=https://some-domain.com");
+          put(MANIFEST_URL, "--manifest-url=https://some-domain.com");
+          put(MANIFEST_FILE, "--manifest-file=somefile");
+          put(ARTIFACTS_REPO_URL, "--artifacts-repo-url=https://some-domain.com");
+          put(CACHE_DIR, "--cache-dir=somefile");
+          put(LOG_FILE, "--log-file=somefile");
+          put(IGNORE_SSL, "--ignore-ssl");
+          put(OFFLINE, "--offline");
+          put(STOP_ON_UPDATE_ERROR, "--stop-on-update-error");
+          put(ACCEPT_DOWNGRADE, "--accept-downgrade");
+          put(PRELOAD_NATIVE_LIBS, "--preload-native-libs=list,of,libs");
+          put(HEADLESS, "--headless");
+          put(WHATS_NEW_URL, "--whats-new-url=https://some-url");
+          put(LINGERING_UPDATE_SCREEN, "--lingering-update-screen");
+        }
+      };
 
-	protected static final Resolver getExpectedResolver(LauncherOption opt) {
-		switch (opt) {
-		case CACHE_DIR:
-			return Resolver.CACHE_DIR;
-		default:
-			return Resolver.DEFAULT;
-		}
-	}
+  protected static final Resolver getExpectedResolver(LauncherOption opt) {
+    switch (opt) {
+      case CACHE_DIR:
+        return Resolver.CACHE_DIR;
+      case IGNORE_SSL:
+      case OFFLINE:
+      case STOP_ON_UPDATE_ERROR:
+      case ACCEPT_DOWNGRADE:
+      case HEADLESS:
+      case LINGERING_UPDATE_SCREEN:
+        return Resolver.BOOL;
+      default:
+        return Resolver.DEFAULT;
+    }
+  }
 
-	protected static final Validator getExpectedValidator(LauncherOption opt) {
-		switch (opt) {
-		case OVERRIDES_URL:
-		case MANIFEST_URL:
-		case ARTIFACTS_REPO_URL:
-		case WHATS_NEW_URL:
-			return Validator.URL;
-		case IGNORE_SSL:
-		case OFFLINE:
-		case STOP_ON_UPDATE_ERROR:
-		case ACCEPT_DOWNGRADE:
-		case HEADLESS:
-		case LINGERING_UPDATE_SCREEN:
-			return Validator.BOOL;
-		default:
-			return Validator.DEFAULT;
-		}
+  protected static final Validator getExpectedValidator(LauncherOption opt) {
+    switch (opt) {
+      case OVERRIDES_URL:
+      case MANIFEST_URL:
+      case ARTIFACTS_REPO_URL:
+      case WHATS_NEW_URL:
+        return Validator.URL;
+      case IGNORE_SSL:
+      case OFFLINE:
+      case STOP_ON_UPDATE_ERROR:
+      case ACCEPT_DOWNGRADE:
+      case HEADLESS:
+      case LINGERING_UPDATE_SCREEN:
+        return Validator.BOOL;
+      default:
+        return Validator.DEFAULT;
+    }
+  }
 
-	}
+  protected static Set<String> expectedLabels = labelMap.values().stream().collect(toSet());
 
-	protected static Set<String> expectedLabels = labelMap.values().stream().collect(toSet());
+  private static final Random random = new Random();
+  private static final int maxIndex = LauncherOption.values().length - 1;
 
-	private static final Random random = new Random();
-	private static final int maxIndex = LauncherOption.values().length - 1;
+  protected LifecyclePhase getRandomNonStartupPhase() {
+    int index = random.nextInt(maxIndex - 1) + 1;
+    return LifecyclePhase.values()[index];
+  }
 
-	protected LifecyclePhase getRandomNonStartupPhase() {
-		int index = random.nextInt(maxIndex - 1) + 1;
-		return LifecyclePhase.values()[index];
-	}
-
-	protected Set<LauncherOption> getValueSet() {
-		return Stream.of(LauncherOption.values()).collect(toSet());
-	}
+  protected Set<LauncherOption> getValueSet() {
+    return Stream.of(LauncherOption.values()).collect(toSet());
+  }
 }

--- a/src/test/java/fxlauncher/config/ResolverTest.java
+++ b/src/test/java/fxlauncher/config/ResolverTest.java
@@ -1,5 +1,7 @@
 package fxlauncher.config;
 
+import static fxlauncher.model.OS.WIN;
+import static fxlauncher.testutils.ReflectionTools.updateEnv;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,78 +15,83 @@ import fxlauncher.model.OS;
 
 public class ResolverTest extends ResolverTestHarness {
 
-	@DisplayName("Resolver.DEFAULT...")
-	@ParameterizedTest(name = "returns \"{0}\" unchanged")
-	@ValueSource(strings = { "", "null", "someString" })
-	public void defaultResolverTest(String input) {
-		input = input.equals("null") ? null : input;
-		assertEquals(input, Resolver.DEFAULT.apply(input));
-	}
+  @DisplayName("Resolver.DEFAULT...")
+  @ParameterizedTest(name = "returns \"{0}\" unchanged")
+  @ValueSource(strings = {"", "null", "someString"})
+  public void defaultResolverTest(String input) {
+    input = input.equals("null") ? null : input;
+    assertEquals(input, Resolver.DEFAULT.apply(input));
+  }
 
-	@DisplayName("Resolver.CACHE_DIR...")
-	@Nested
-	class CacheDirResolver {
+  @DisplayName("Resolver.CACHE_DIR...")
+  @Nested
+  class CacheDirResolver {
 
-		@DisplayName("when handling ALLUSERS sentinel...")
-		@Nested
-		class AllUsersTests {
+    @DisplayName("when handling ALLUSERS sentinel...")
+    @Nested
+    class AllUsersTests {
 
-			@DisplayName("resolves leading ALLUSERS for...")
-			@ParameterizedTest(name = "OS {0}")
-			@EnumSource(OS.class)
-			void resolveAllUsersAtStartOfPath(OS os) {
-				setCurrentOS(os);
+      @DisplayName("resolves leading ALLUSERS for...")
+      @ParameterizedTest(name = "OS {0}")
+      @EnumSource(OS.class)
+      void resolveAllUsersAtStartOfPath(OS os) {
+        setCurrentOS(os);
 
-				String inputPath = "ALLUSERS/TEST/PATH";
-				assertEquals(expectedAllUsersPathMap.get(os), Resolver.CACHE_DIR.apply(inputPath));
-			}
+        String inputPath = "ALLUSERS/TEST/PATH";
+        assertEquals(expectedAllUsersPathMap.get(os), Resolver.CACHE_DIR.apply(inputPath));
+      }
 
-			@DisplayName("ignores non-leading ALLUSERS for...")
-			@ParameterizedTest(name = "OS {0}")
-			@EnumSource(OS.class)
-			void ignoreNonLeadingAllUsers(OS os) {
-				setCurrentOS(os);
+      @DisplayName("ignores non-leading ALLUSERS for...")
+      @ParameterizedTest(name = "OS {0}")
+      @EnumSource(OS.class)
+      void ignoreNonLeadingAllUsers(OS os) throws ReflectiveOperationException {
 
-				String inputPath = "TEST/ALLUSERS/PATH";
-				assertEquals(inputPath, Resolver.CACHE_DIR.apply(inputPath));
-			}
-		}
+        if (os == WIN) {
+          updateEnv("ALLUSERSPROFILE", "TEST_ALLUSERS_PROFILE");
+        }
 
-		@DisplayName("when handling USERLIB sentinel...")
-		@Nested
-		class UserLibTests {
+        setCurrentOS(os);
 
-			@DisplayName("resolves leading USERLIB for...")
-			@ParameterizedTest(name = "OS {0}")
-			@EnumSource(OS.class)
-			void resolveAllUsersAtStartOfPath(OS os) {
-				setCurrentOS(os);
+        String inputPath = "TEST/ALLUSERS/PATH";
+        assertEquals(inputPath, Resolver.CACHE_DIR.apply(inputPath));
+      }
+    }
 
-				String inputPath = "USERLIB/TEST/PATH";
-				assertEquals(expectedUserLibPathMap.get(os), Resolver.CACHE_DIR.apply(inputPath));
-			}
+    @DisplayName("when handling USERLIB sentinel...")
+    @Nested
+    class UserLibTests {
 
-			@DisplayName("ignores non-leading ALLUSERS for...")
-			@ParameterizedTest(name = "OS {0}")
-			@EnumSource(OS.class)
-			void ignoreNonLeadingAllUsers(OS os) {
-				setCurrentOS(os);
+      @DisplayName("resolves leading USERLIB for...")
+      @ParameterizedTest(name = "OS {0}")
+      @EnumSource(OS.class)
+      void resolveAllUsersAtStartOfPath(OS os) {
+        setCurrentOS(os);
 
-				String inputPath = "TEST/USERLIB/PATH";
-				assertEquals(inputPath, Resolver.CACHE_DIR.apply(inputPath));
-			}
-		}
+        String inputPath = "USERLIB/TEST/PATH";
+        assertEquals(expectedUserLibPathMap.get(os), Resolver.CACHE_DIR.apply(inputPath));
+      }
 
-		@DisplayName("When handling a null path, returns it unchanged")
-		@Test
-		void testNullHandling() {
-			assertEquals(null, Resolver.CACHE_DIR.apply(null));
-		}
+      @DisplayName("ignores non-leading ALLUSERS for...")
+      @ParameterizedTest(name = "OS {0}")
+      @EnumSource(OS.class)
+      void ignoreNonLeadingAllUsers(OS os) {
+        setCurrentOS(os);
 
-		@DisplayName("When handling an empty String, returns it unchanged")
-		@Test
-		void testEmptyStringHandling() {
-			assertEquals("", Resolver.CACHE_DIR.apply(""));
-		}
-	}
+        String inputPath = "TEST/USERLIB/PATH";
+        assertEquals(inputPath, Resolver.CACHE_DIR.apply(inputPath));
+      }
+    }
+
+    @DisplayName("When handling a null path, returns it unchanged")
+    @Test
+    void testNullHandling() {
+      assertEquals(null, Resolver.CACHE_DIR.apply(null));
+    }
+
+    @DisplayName("When handling an empty String, returns it unchanged")
+    @Test
+    void testEmptyStringHandling() {
+      assertEquals("", Resolver.CACHE_DIR.apply(""));
+    }
+  }
 }

--- a/src/test/java/fxlauncher/config/ResolverTestHarness.java
+++ b/src/test/java/fxlauncher/config/ResolverTestHarness.java
@@ -20,51 +20,46 @@ import fxlauncher.testutils.ReflectionTools;
 
 public class ResolverTestHarness {
 
-	static {
-		try {
-			ReflectionTools.updateEnv("ALLUSERSPROFILE", "TEST_ALLUSERS_PROFILE");
-		} catch (ReflectiveOperationException e) {
-			e.printStackTrace();
-		}
-	}
+  protected static final Map<OS, String> expectedAllUsersPathMap =
+      new EnumMap<OS, String>(OS.class);
+  protected static final Map<OS, String> expectedUserLibPathMap = new EnumMap<OS, String>(OS.class);
+  private static final String HOME_PATH = System.getProperty("user.home");
+  private static final String SEP = File.separator;
 
-	protected static final Map<OS, String> expectedAllUsersPathMap = new EnumMap<OS, String>(OS.class);
-	protected static final Map<OS, String> expectedUserLibPathMap = new EnumMap<OS, String>(OS.class);
-	private static final String HOME_PATH = System.getProperty("user.home");
-	private static final String SEP = File.separator;
+  protected OS startingOS;
 
-	protected OS startingOS;
+  @BeforeEach
+  void captureCurrentOS() {
+    startingOS = OS.current;
+  }
 
-	@BeforeEach
-	void captureCurrentOS() throws ReflectiveOperationException {
-		startingOS = OS.current;
-	}
+  @AfterEach
+  void restoreStartingOS() {
+    setCurrentOS(startingOS);
+  }
 
-	@AfterEach
-	void restoreStartingOS() {
-		setCurrentOS(startingOS);
-	}
+  @BeforeAll
+  static void init() {
+    expectedAllUsersPathMap.put(MAC, "/Library/Application Support/TEST/PATH");
+    expectedAllUsersPathMap.put(WIN, "TEST_ALLUSERS_PROFILE/TEST/PATH");
+    expectedAllUsersPathMap.put(LINUX, "/usr/local/share/TEST/PATH");
+    expectedAllUsersPathMap.put(OTHER, "/usr/local/share/TEST/PATH");
 
-	@BeforeAll
-	static void init() {
-		expectedAllUsersPathMap.put(MAC, "/Library/Application Support/TEST/PATH");
-		expectedAllUsersPathMap.put(WIN, "TEST_ALLUSERS_PROFILE/TEST/PATH");
-		expectedAllUsersPathMap.put(LINUX, "/usr/local/share/TEST/PATH");
-		expectedAllUsersPathMap.put(OTHER, "/usr/local/share/TEST/PATH");
+    expectedUserLibPathMap.put(
+        MAC,
+        Stream.of(HOME_PATH, "Library", "Application Support", "TEST", "PATH")
+            .collect(joining(SEP)));
+    expectedUserLibPathMap.put(
+        WIN, Stream.of(HOME_PATH, "AppData", "Local", "TEST", "PATH").collect(joining(SEP)));
+    expectedUserLibPathMap.put(LINUX, Stream.of(HOME_PATH, "TEST", "PATH").collect(joining(SEP)));
+    expectedUserLibPathMap.put(OTHER, Stream.of(HOME_PATH, "TEST", "PATH").collect(joining(SEP)));
+  }
 
-		expectedUserLibPathMap.put(MAC,
-				Stream.of(HOME_PATH, "Library", "Application Support", "TEST", "PATH").collect(joining(SEP)));
-		expectedUserLibPathMap.put(WIN, Stream.of(HOME_PATH, "AppData", "Local", "TEST", "PATH").collect(joining(SEP)));
-		expectedUserLibPathMap.put(LINUX, Stream.of(HOME_PATH, "TEST", "PATH").collect(joining(SEP)));
-		expectedUserLibPathMap.put(OTHER, Stream.of(HOME_PATH, "TEST", "PATH").collect(joining(SEP)));
-	}
-
-	protected void setCurrentOS(OS newCurrentOS) {
-		try {
-			ReflectionTools.setCurrentOS(newCurrentOS);
-		} catch (Exception e) {
-			throw new IllegalStateException("unable to change current OS", e);
-		}
-	}
-
+  protected void setCurrentOS(OS newCurrentOS) {
+    try {
+      ReflectionTools.setCurrentOS(newCurrentOS);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to change current OS", e);
+    }
+  }
 }

--- a/src/test/java/fxlauncher/config/ValidatorTest.java
+++ b/src/test/java/fxlauncher/config/ValidatorTest.java
@@ -10,60 +10,73 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class ValidatorTest {
 
-	@Nested
-	@DisplayName("The default implementation of Validator...")
-	class DefaultValidator {
+  @Nested
+  @DisplayName("The default implementation of Validator...")
+  class DefaultValidator {
 
-		@DisplayName("returns true for every String")
-		@ParameterizedTest(name = "returns true for input \"{0}\"")
-		@ValueSource(strings = { "", "null", "Some string", "https://some-domain.com?query", "false" })
-		public void returnsTrue(String input) {
+    @DisplayName("returns true for every non-empty String")
+    @ParameterizedTest(name = "returns true for input \"{0}\"")
+    @ValueSource(strings = {"Some string", "https://some-domain.com?query", "false"})
+    public void returnsTrue(String input) {
+      input = input.equals("null") ? null : input;
+      assertTrue(Validator.DEFAULT.test(input));
+    }
 
-			input = input.equals("null") ? null : input;
-			assertTrue(Validator.DEFAULT.test(input));
-		}
-	}
+    @DisplayName("returns false for empty or null Strings")
+    @ParameterizedTest(name = "returns false for input \"{0}\"")
+    @ValueSource(strings = {"null", "", "  "})
+    public void returnsFalse(String input) {
+      input = input.equals("null") ? null : input;
+      assertFalse(Validator.DEFAULT.test(input));
+    }
+  }
 
-	@Nested
-	@DisplayName("Validator.BOOLEAN...")
-	class BooleanValidator {
+  @Nested
+  @DisplayName("Validator.BOOLEAN...")
+  class BooleanValidator {
 
-		@DisplayName("returns true for appropriate boolean values")
-		@ParameterizedTest(name = "returns true for \"{0}\"")
-		@ValueSource(strings = { "true", "TRUE", "True", "TrUe", "false", "FALSE", "False", "fAlSe" })
-		public void returnsTrue(String input) {
-			assertTrue(Validator.BOOL.test(input));
-		}
+    @DisplayName("returns true for appropriate boolean values")
+    @ParameterizedTest(name = "returns true for \"{0}\"")
+    @ValueSource(
+        strings = {
+          "true", "TRUE", "True", "TrUe", "false", "FALSE", "False", "fAlSe", "", "  ", "null"
+        })
+    public void returnsTrue(String input) {
+      input = input.equals("null") ? null : input;
+      assertTrue(Validator.BOOL.test(input));
+    }
 
-		@DisplayName("returns false for non-boolean Strings")
-		@ParameterizedTest(name = "returns false for \"{0}\"")
-		@ValueSource(strings = { "", "null", "Some string", "https://some-domain.com?query" })
-		public void returnsFalse(String input) {
-			input = input.equals("null") ? null : input;
-			assertFalse(Validator.BOOL.test(input));
-		}
-	}
+    @DisplayName("returns false for non-boolean Strings")
+    @ParameterizedTest(name = "returns false for \"{0}\"")
+    @ValueSource(strings = {"Some string", "https://some-domain.com?query"})
+    public void returnsFalse(String input) {
+      assertFalse(Validator.BOOL.test(input));
+    }
+  }
 
-	@Nested
-	@DisplayName("Validator.URL...")
-	class URLValidator {
-		/*
-		 * testing every possible valid URL seems imprudent I would suggest adding more
-		 * variations to the ValueSource annotation as they become needed
-		 */
-		@DisplayName("returns true for a valid URL")
-		@ParameterizedTest(name = "returns true for \"{0}\"")
-		@ValueSource(strings = { "https://some-domain.com/file.txt?key=value,key=value", })
-		public void returnsTrue(String input) {
-			assertTrue(Validator.URL.test(input));
-		}
+  @Nested
+  @DisplayName("Validator.URL...")
+  class URLValidator {
+    /*
+     * testing every possible valid URL seems imprudent I would suggest adding more
+     * variations to the ValueSource annotation as they become needed
+     */
+    @DisplayName("returns true for a valid URL")
+    @ParameterizedTest(name = "returns true for \"{0}\"")
+    @ValueSource(
+        strings = {
+          "https://some-domain.com/file.txt?key=value,key=value",
+        })
+    public void returnsTrue(String input) {
+      assertTrue(Validator.URL.test(input));
+    }
 
-		@DisplayName("returns false for any non-URL string")
-		@ParameterizedTest(name = "returns false for \"{0}\"")
-		@ValueSource(strings = { "", "null", "Some string", "false" })
-		public void returnsFalse(String input) {
-			input = input.equals("null") ? null : input;
-			assertFalse(Validator.URL.test(input));
-		}
-	}
+    @DisplayName("returns false for any non-URL string")
+    @ParameterizedTest(name = "returns false for \"{0}\"")
+    @ValueSource(strings = {"", "null", "Some string", "false"})
+    public void returnsFalse(String input) {
+      input = input.equals("null") ? null : input;
+      assertFalse(Validator.URL.test(input));
+    }
+  }
 }

--- a/src/test/java/fxlauncher/config/ingest/ArgsIngesterTest.java
+++ b/src/test/java/fxlauncher/config/ingest/ArgsIngesterTest.java
@@ -1,0 +1,80 @@
+package fxlauncher.config.ingest;
+
+import static fxlauncher.config.LauncherOption.ACCEPT_DOWNGRADE;
+import static fxlauncher.config.LauncherOption.ARTIFACTS_REPO_URL;
+import static fxlauncher.config.LauncherOption.CACHE_DIR;
+import static fxlauncher.config.LauncherOption.CONFIG_FILE;
+import static fxlauncher.config.LauncherOption.HEADLESS;
+import static fxlauncher.config.LauncherOption.LINGERING_UPDATE_SCREEN;
+import static fxlauncher.config.LauncherOption.LOG_FILE;
+import static fxlauncher.config.LauncherOption.MANIFEST_FILE;
+import static fxlauncher.config.LauncherOption.MANIFEST_URL;
+import static fxlauncher.config.LauncherOption.OFFLINE;
+import static fxlauncher.config.LauncherOption.OVERRIDES_URL;
+import static fxlauncher.config.LauncherOption.PRELOAD_NATIVE_LIBS;
+import static fxlauncher.config.LauncherOption.STOP_ON_UPDATE_ERROR;
+import static fxlauncher.config.LauncherOption.WHATS_NEW_URL;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArgsIngesterTest extends ArgsIngesterTestHarness {
+
+    @DisplayName("Correctly handles a single command-line arguments")
+    @Test
+    public void simpleHappyPathTest() {
+	setArgs("--cache-dir=some-directory");
+	expectIngestOpCalledWith(CACHE_DIR, "some-directory");
+
+	ingester.ingest();
+
+	verifyExpectedIngestOpCalls();
+	assertEmptyDownstreamParams();
+    }
+
+    @DisplayName("Sets all launcher options based on command-line arguments")
+    @Test
+    public void allOptsHappyPathTest() {
+	setArgs(ALL_ARGS);
+
+	expectIngestOpCalledWith(CONFIG_FILE, "test-config-file");
+	expectIngestOpCalledWith(OVERRIDES_URL, "https://test.override/url");
+	expectIngestOpCalledWith(MANIFEST_URL, "https://test.manifest/url");
+	expectIngestOpCalledWith(MANIFEST_FILE, "test-manifest-file");
+	expectIngestOpCalledWith(ARTIFACTS_REPO_URL, "https://test.artifacts/repo/url");
+	expectIngestOpCalledWith(CACHE_DIR, "test-cache-dir");
+	expectIngestOpCalledWith(LOG_FILE, "test-log-file");
+	expectIngestOpCalledWith(OFFLINE, null);
+	expectIngestOpCalledWith(STOP_ON_UPDATE_ERROR, null);
+	expectIngestOpCalledWith(ACCEPT_DOWNGRADE, null);
+	expectIngestOpCalledWith(PRELOAD_NATIVE_LIBS, "list,of,native,libraries");
+	expectIngestOpCalledWith(HEADLESS, null);
+	expectIngestOpCalledWith(WHATS_NEW_URL, "https://whats.new/url");
+	expectIngestOpCalledWith(LINGERING_UPDATE_SCREEN, null);
+
+	ingester.ingest();
+
+	verifyExpectedIngestOpCalls();
+	assertEmptyDownstreamParams();
+    }
+
+    @Test
+    public void downstreamParamsTest() {
+	setArgs("--cache-dir=some-directory", "--downstream-param=downstream-param-value", "--downstream-flag",
+		"downstream-arg");
+
+	expectIngestOpCalledWith(CACHE_DIR, "some-directory");
+
+	expectDownstreamNamed("downstream-param", "downstream-param-value");
+	expectDownstreamUnnamed("--downstream-flag");
+	expectDownstreamUnnamed("downstream-arg");
+
+	ingester.ingest();
+
+	verifyExpectedIngestOpCalls();
+	assertExpectedDownstreamParams();
+    }
+}

--- a/src/test/java/fxlauncher/config/ingest/ArgsIngesterTestHarness.java
+++ b/src/test/java/fxlauncher/config/ingest/ArgsIngesterTestHarness.java
@@ -1,0 +1,31 @@
+package fxlauncher.config.ingest;
+
+import static java.util.stream.Collectors.joining;
+import static org.mockito.Mockito.lenient;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+public abstract class ArgsIngesterTestHarness extends ConfigIngesterTestHarness {
+
+    @InjectMocks
+    protected ArgsIngester ingester;
+
+    @Mock
+    protected Supplier<String[]> argsSupplier;
+
+    protected static final String[] ALL_ARGS = { "--config-file=test-config-file",
+	    "--overrides-url=https://test.override/url", "--manifest-url=https://test.manifest/url",
+	    "--manifest-file=test-manifest-file", "--artifacts-repo-url=https://test.artifacts/repo/url",
+	    "--cache-dir=test-cache-dir", "--log-file=test-log-file", "--ignore-ssl", "--offline",
+	    "--stop-on-update-error", "--accept-downgrade", "--preload-native-libs=list,of,native,libraries",
+	    "--headless", "--whats-new-url=https://whats.new/url", "--lingering-update-screen", };
+
+    protected void setArgs(String... args) {
+	log.info("Setting arguments for test: " + Stream.of(args).collect(joining("\", \"", "[\"", "\"]")));
+	lenient().when(argsSupplier.get()).then(invocation -> args);
+    }
+}

--- a/src/test/java/fxlauncher/config/ingest/ConfigIngesterTestHarness.java
+++ b/src/test/java/fxlauncher/config/ingest/ConfigIngesterTestHarness.java
@@ -1,0 +1,117 @@
+package fxlauncher.config.ingest;
+
+import static fxlauncher.testutils.CollectionTools.asSet;
+import static fxlauncher.testutils.CollectionTools.assertMapEquals;
+import static fxlauncher.testutils.LoggingTools.initTestLog;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.logging.Logger.getLogger;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.logging.Logger;
+
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+import fxlauncher.config.LauncherOption;
+import fxlauncher.downstream.DownstreamParameters;
+
+public abstract class ConfigIngesterTestHarness {
+
+    protected static final Logger log = initTestLog(getLogger(ArgsIngesterTestHarness.class.getName()));
+
+    @Mock
+    protected BiConsumer<LauncherOption, String> ingestOp;
+
+    @Spy
+    private DownstreamParameters observableOverflowParameters;
+
+    // Collection of LauncherOption, String pairs expected to be passed to
+    // LauncherConfig::setOption
+    private final List<OptionPair> expectedConfig = new ArrayList<>();
+
+    // Collections expected to match the captured downstream parameters
+    private final Map<String, String> expectedNamed = new HashMap<>();
+    private final List<String> expectedUnnamed = new ArrayList<>();
+    private final List<String> expectedRaw = new ArrayList<>();
+
+    protected void expectIngestOpCalledWith(LauncherOption opt, String value) {
+	expectedConfig.add(new OptionPair(opt, value));
+    }
+
+    protected void expectDownstreamNamed(String key, String value) {
+	expectedNamed.put(key, value);
+	expectedRaw.add(String.format("--%s=%s", key, value));
+    }
+
+    protected void expectDownstreamUnnamed(String arg) {
+	expectedUnnamed.add(arg);
+	expectedRaw.add(arg);
+    }
+
+    protected void assertExpectedDownstreamParams() {
+	assertAll(() -> assertMapEquals(expectedNamed, observableOverflowParameters.getNamed()),
+		() -> assertEquals(expectedUnnamed, observableOverflowParameters.getUnnamed()),
+		// wrapping in Set because passing through the Properties type loses any
+		// ordering that exists in the original properties file.
+		() -> assertEquals(asSet(expectedRaw), asSet(observableOverflowParameters.getRaw())),
+		() -> assertEquals(asSet(expectedRaw), asSet(observableOverflowParameters.getArgs())));
+    }
+
+    protected void assertNoConfigCaptured() {
+	assertAll(() -> assertEquals(emptyMap(), observableOverflowParameters.getNamed()),
+		() -> assertEquals(emptyList(), observableOverflowParameters.getRaw()),
+		() -> assertEquals(emptyList(), observableOverflowParameters.getRaw()),
+		() -> assertArrayEquals(new String[0], observableOverflowParameters.getArgs()));
+    }
+
+    protected void assertEmptyDownstreamParams() {
+	assertAll(() -> assertMapEquals(emptyMap(), observableOverflowParameters.getNamed()),
+		() -> assertEquals(emptyList(), observableOverflowParameters.getUnnamed()),
+		// wrapping in Set because passing through the Properties type loses any
+		// ordering that exists in the original properties file.
+		() -> assertEquals(emptyList(), observableOverflowParameters.getRaw()),
+		() -> assertArrayEquals(new String[0], observableOverflowParameters.getArgs()));
+
+    };
+
+    protected void verifyExpectedIngestOpCalls() {
+	for (OptionPair pair : expectedConfig) {
+	    verify(ingestOp, times(1)).accept(pair.getOption(), pair.getValue());
+	}
+    }
+
+    protected void verifyNoIngestOpCalls() {
+	verify(ingestOp, never()).accept(any(LauncherOption.class), anyString());
+    }
+
+    protected static class OptionPair {
+	private LauncherOption option;
+	private String value;
+
+	private OptionPair(LauncherOption option, String value) {
+	    this.option = option;
+	    this.value = value;
+	}
+
+	protected LauncherOption getOption() {
+	    return option;
+	}
+
+	protected String getValue() {
+	    return value;
+	}
+    }
+}

--- a/src/test/java/fxlauncher/config/ingest/PropertiesFileIngesterTest.java
+++ b/src/test/java/fxlauncher/config/ingest/PropertiesFileIngesterTest.java
@@ -1,0 +1,86 @@
+package fxlauncher.config.ingest;
+
+import static fxlauncher.config.LauncherOption.ACCEPT_DOWNGRADE;
+import static fxlauncher.config.LauncherOption.ARTIFACTS_REPO_URL;
+import static fxlauncher.config.LauncherOption.CACHE_DIR;
+import static fxlauncher.config.LauncherOption.CONFIG_FILE;
+import static fxlauncher.config.LauncherOption.HEADLESS;
+import static fxlauncher.config.LauncherOption.LINGERING_UPDATE_SCREEN;
+import static fxlauncher.config.LauncherOption.LOG_FILE;
+import static fxlauncher.config.LauncherOption.MANIFEST_FILE;
+import static fxlauncher.config.LauncherOption.MANIFEST_URL;
+import static fxlauncher.config.LauncherOption.OFFLINE;
+import static fxlauncher.config.LauncherOption.OVERRIDES_URL;
+import static fxlauncher.config.LauncherOption.PRELOAD_NATIVE_LIBS;
+import static fxlauncher.config.LauncherOption.STOP_ON_UPDATE_ERROR;
+import static fxlauncher.config.LauncherOption.WHATS_NEW_URL;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PropertiesFileIngesterTest extends PropertiesFileIngesterTestHarness {
+
+    @DisplayName("Happy-path test of ingesting properties and passing overflow to downstream parameters object")
+    @Test
+    void ingestsTestProperties() {
+	setResourceName("/test.launcher.properties");
+
+	// predict expected outcomes...
+	// values below defined in default test properties file
+	expectIngestOpCalledWith(CONFIG_FILE, "test-config-file");
+	expectIngestOpCalledWith(OVERRIDES_URL, "https://test.override/url");
+	expectIngestOpCalledWith(MANIFEST_URL, "https://test.manifest/url");
+	expectIngestOpCalledWith(MANIFEST_FILE, "test-manifest-file");
+	expectIngestOpCalledWith(ARTIFACTS_REPO_URL, "https://test.artifacts/repo/url");
+	expectIngestOpCalledWith(CACHE_DIR, "test-cache-dir");
+	expectIngestOpCalledWith(LOG_FILE, "test-log-file");
+	expectIngestOpCalledWith(OFFLINE, "");
+	expectIngestOpCalledWith(STOP_ON_UPDATE_ERROR, "");
+	expectIngestOpCalledWith(ACCEPT_DOWNGRADE, "");
+	expectIngestOpCalledWith(PRELOAD_NATIVE_LIBS, "list,of,native,libraries");
+	expectIngestOpCalledWith(HEADLESS, "");
+	expectIngestOpCalledWith(WHATS_NEW_URL, "https://whats.new/url");
+	expectIngestOpCalledWith(LINGERING_UPDATE_SCREEN, "");
+
+	expectDownstreamNamed("downstream-prop", "downstream-prop-value");
+	expectDownstreamUnnamed("--downstream-flag");
+
+	// initiate test
+	ingester.ingest();
+
+	// verify expected flow occurred
+	assertTrue(fileWasFound);
+	verifyHappyPath();
+	// confirm end-state is as expected
+	assertExpectedDownstreamParams();
+    }
+
+    @DisplayName("Unhappy-path test for missing properties file")
+    @Test
+    void fileNotFoundTest() {
+	setResourceName("/this-file-doesnt-exist");
+
+	ingester.ingest();
+
+	assertFalse(fileWasFound);
+	verifyNotFoundPath();
+	assertNoConfigCaptured();
+    }
+
+    @DisplayName("Unhappy path-test for properties file with malformed input")
+    @Test
+    void invalidFileTest() {
+	setResourceName("/invalid.launcher.properties");
+
+	ingester.ingest();
+
+	assertTrue(fileWasFound);
+	verifyNotFoundPath();
+	assertNoConfigCaptured();
+    }
+}

--- a/src/test/java/fxlauncher/config/ingest/PropertiesFileIngesterTestHarness.java
+++ b/src/test/java/fxlauncher/config/ingest/PropertiesFileIngesterTestHarness.java
@@ -1,0 +1,76 @@
+package fxlauncher.config.ingest;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import fxlauncher.tools.io.ClasspathResourceFetcher;
+
+public abstract class PropertiesFileIngesterTestHarness extends ConfigIngesterTestHarness {
+
+    protected String resourceName = null;
+
+    @InjectMocks
+    protected PropertiesFileIngester ingester;
+
+    @Mock
+    protected Function<String, ClasspathResourceFetcher> fetcherFactory;
+
+    @Mock
+    protected Supplier<String> resourceNameSupplier;
+    protected ClasspathResourceFetcher observableFetcher;
+
+    protected boolean fileWasFound = false;
+
+    protected void setResourceName(String resourceName) {
+	log.info("setting resource name to: " + resourceName);
+	this.resourceName = resourceName;
+
+	// provides a mechanism for swapping in non-default resource names for
+	// appropriate tests
+	when(resourceNameSupplier.get()).thenAnswer(invocation -> resourceName);
+	initFetcherFactory();
+    }
+
+    private void initFetcherFactory() {
+	observableFetcher = spy(new ClasspathResourceFetcher(resourceNameSupplier.get()));
+	// make mocked fetcherFactory() return a fetcher for the current
+	// resourceName.
+	// Capture the fetcher in a variable so calls against it can be verified
+	when(fetcherFactory.apply(anyString())).thenAnswer(invocation -> {
+	    log.info("returning ClasspathResourceFetcher spy from call to fetcherFactory.apply()");
+	    return observableFetcher;
+	});
+
+	lenient().when(observableFetcher.fetch()).thenAnswer(invocation -> {
+	    @SuppressWarnings("unchecked")
+	    Optional<InputStream> result = (Optional<InputStream>) invocation.callRealMethod();
+	    fileWasFound = result.isPresent();
+	    return result;
+	});
+    }
+
+    public void verifyHappyPath() {
+	verify(fetcherFactory, times(1)).apply(resourceName);
+	verify(observableFetcher, times(1)).fetch();
+	verifyExpectedIngestOpCalls();
+    }
+
+    public void verifyNotFoundPath() {
+	verify(fetcherFactory, times(1)).apply(resourceName);
+	verify(observableFetcher, times(1)).fetch();
+	verifyNoIngestOpCalls();
+    }
+
+}

--- a/src/test/java/fxlauncher/downstream/DownstreamParametersTest.java
+++ b/src/test/java/fxlauncher/downstream/DownstreamParametersTest.java
@@ -1,0 +1,122 @@
+package fxlauncher.downstream;
+
+import static fxlauncher.testutils.CollectionTools.assertMapEquals;
+import static fxlauncher.testutils.CollectionTools.generateList;
+import static fxlauncher.testutils.CollectionTools.generateMap;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class DownstreamParametersTest {
+
+	private DownstreamParameters params = new DownstreamParameters();
+
+	@DisplayName("Test that inputs are merged into appropriate categories")
+	@Test
+	public void testGenericMergeNoCollisions() {
+		String[] keys = { "key" };
+		String[] values = { "myvalue" };
+		Map<String, String> expectedNamed = generateMap(keys, values);
+		List<String> expectedUnnamed = generateList("--flag", "argument");
+		String[] expectedArgs = { "--key=myvalue", "--flag", "argument" };
+		List<String> expectedRaw = generateList(expectedArgs);
+
+		assertMapEquals(emptyMap(), params.getNamed());
+
+		params.merge("--key=myvalue", false);
+		params.merge("--flag", false);
+		params.merge("argument", false);
+
+		assertMapEquals(expectedNamed, params.getNamed());
+		assertEquals(expectedUnnamed, params.getUnnamed());
+		assertArrayEquals(expectedArgs, params.getArgs());
+		assertEquals(expectedRaw, params.getRaw());
+	}
+
+	@DisplayName("Generic merge merges named parameters correctly...")
+	@ParameterizedTest(name = "when overwrite is {0}")
+	@ValueSource(booleans = { true, false })
+	public void testGenericMergeOfNamedParameters(boolean overwriting) {
+		String[] keys = { "key" }, values1 = { "firstvalue" }, values2 = { "secondvalue" };
+
+		Map<String, String> afterOverwrite = generateMap(keys, values1);
+		Map<String, String> beforeOverwrite = generateMap(keys, values2);
+		String[] finalArgs = { "--key=firstvalue", "--key=secondvalue" };
+		List<String> finalRaw = Arrays.asList(finalArgs);
+
+		assertMapEquals(Collections.emptyMap(), params.getNamed());
+
+		params.merge("--key=firstvalue", overwriting);
+		assertMapEquals(afterOverwrite, params.getNamed());
+
+		params.merge("--key=secondvalue", overwriting);
+		assertMapEquals(overwriting ? beforeOverwrite : afterOverwrite, params.getNamed());
+
+		assertEquals(finalRaw, params.getRaw());
+		assertArrayEquals(finalArgs, params.getArgs());
+	}
+
+	@DisplayName("mergeOverwriting() behaves the same as generic merge with overwrite=true")
+	@Test
+	void testMergeOverwriting() {
+		DownstreamParameters params2 = new DownstreamParameters();
+
+		String[] keys = { "key" }, values1 = { "firstvalue" }, values2 = { "secondvalue" };
+
+		Map<String, String> afterOverwrite = generateMap(keys, values1);
+		Map<String, String> beforeOverwrite = generateMap(keys, values2);
+		String[] finalArgs = { "--key=firstvalue", "--key=secondvalue" };
+		List<String> finalRaw = Arrays.asList(finalArgs);
+
+		assertMapEquals(params.getNamed(), params2.getNamed());
+
+		params.merge("--key=firstvalue", true);
+		params2.mergeOverwriting("--key=firstvalue");
+		assertMapEquals(params.getNamed(), params2.getNamed());
+
+		params.merge("--key=secondvalue", true);
+		params2.mergeOverwriting("--key=secondvalue");
+		assertMapEquals(params.getNamed(), params2.getNamed());
+
+		assertEquals(params.getUnnamed(), params2.getUnnamed());
+		assertEquals(params.getRaw(), params2.getRaw());
+		assertArrayEquals(params.getArgs(), params2.getArgs());
+	}
+
+	@DisplayName("mergeIfNotPresent() behaves the same as generic merge with overwrite=false")
+	@Test
+	void testMergeIfNotPresent() {
+		DownstreamParameters params2 = new DownstreamParameters();
+
+		String[] keys = { "key" }, values1 = { "firstvalue" }, values2 = { "secondvalue" };
+
+		Map<String, String> afterOverwrite = generateMap(keys, values1);
+		Map<String, String> beforeOverwrite = generateMap(keys, values2);
+		String[] finalArgs = { "--key=firstvalue", "--key=secondvalue" };
+		List<String> finalRaw = Arrays.asList(finalArgs);
+
+		assertMapEquals(params.getNamed(), params2.getNamed());
+
+		params.merge("--key=firstvalue", false);
+		params2.mergeIfNotPresent("--key=firstvalue");
+		assertMapEquals(params.getNamed(), params2.getNamed());
+
+		params.merge("--key=secondvalue", false);
+		params2.mergeIfNotPresent("--key=secondvalue");
+		assertMapEquals(params.getNamed(), params2.getNamed());
+
+		assertEquals(params.getUnnamed(), params2.getUnnamed());
+		assertEquals(params.getRaw(), params2.getRaw());
+		assertArrayEquals(params.getArgs(), params2.getArgs());
+	}
+}

--- a/src/test/java/fxlauncher/testutils/CollectionTools.java
+++ b/src/test/java/fxlauncher/testutils/CollectionTools.java
@@ -1,0 +1,55 @@
+package fxlauncher.testutils;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.IntStream.range;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class CollectionTools {
+
+  @SuppressWarnings("unchecked")
+  public static <T> Set<T> generateSet(T... members) {
+    return Stream.of(members).collect(toSet());
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> List<T> generateList(T... members) {
+    return Stream.of(members).collect(toList());
+  }
+
+  public static <K, V> Map<K, V> generateMap(K[] keys, V[] values) {
+    if (keys.length != values.length)
+      throw new IllegalArgumentException("Must be the same number of keys as values");
+    if (Stream.of(keys).distinct().count() != keys.length) {
+      throw new IllegalArgumentException("Keys must be unique.");
+    }
+
+    return range(0, keys.length).boxed().collect(toMap(i -> keys[i], i -> values[i]));
+  };
+
+  public static <K, V> void assertMapEquals(Map<K, V> thisMap, Map<K, V> thatMap) {
+    assertEquals(thisMap.keySet(), thatMap.keySet());
+    thisMap.keySet().forEach(key -> assertEquals(thisMap.get(key), thatMap.get(key)));
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> Set<T> asSet(T... items) {
+    return Stream.of(items).collect(toSet());
+  }
+
+  public static <T> Set<T> asSet(Collection<T> items) {
+    return items.stream().collect(toSet());
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T[] asArray(T... items) {
+    return items;
+  }
+}

--- a/src/test/java/fxlauncher/testutils/LoggingTools.java
+++ b/src/test/java/fxlauncher/testutils/LoggingTools.java
@@ -1,0 +1,24 @@
+package fxlauncher.testutils;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+public class LoggingTools {
+
+  public static Logger initTestLog(Logger log) {
+    log.setUseParentHandlers(false);
+    ConsoleHandler handler = new ConsoleHandler();
+    handler.setFormatter(
+        new Formatter() {
+
+          @Override
+          public String format(LogRecord record) {
+            return String.format("\t[TEST LOG] %s: %s\n", record.getLevel(), record.getMessage());
+          }
+        });
+    log.addHandler(handler);
+    return log;
+  }
+}

--- a/src/test/java/fxlauncher/testutils/ReflectionTools.java
+++ b/src/test/java/fxlauncher/testutils/ReflectionTools.java
@@ -10,41 +10,40 @@ import fxlauncher.model.OS;
  * A collection of reflection-based utility methods to assist in testing
  *
  * @author idavis1
- *
  */
 public class ReflectionTools {
 
-	/**
-	 * Sets an environment variable in the memory-resident representation without
-	 * actually overwriting anything on the underlying system
-	 *
-	 * @param name the name of the environment variable to set
-	 * @param val  the value we want it to have
-	 * @throws Exception if the reflection fails for security reasons
-	 */
-	@SuppressWarnings("unchecked")
-	public static void updateEnv(String name, String val) throws ReflectiveOperationException {
-		Map<String, String> env = System.getenv();
-		Field field = env.getClass().getDeclaredField("m");
-		field.setAccessible(true);
-		((Map<String, String>) field.get(env)).put(name, val);
-	}
+  /**
+   * Sets an environment variable in the memory-resident representation without actually overwriting
+   * anything on the underlying system
+   *
+   * @param name the name of the environment variable to set
+   * @param val the value we want it to have
+   * @throws Exception if the reflection fails for security reasons
+   */
+  @SuppressWarnings("unchecked")
+  public static void updateEnv(String name, String val) throws ReflectiveOperationException {
+    Map<String, String> env = System.getenv();
+    Field field = env.getClass().getDeclaredField("m");
+    field.setAccessible(true);
+    ((Map<String, String>) field.get(env)).put(name, val);
+  }
 
-	/**
-	 * Overwrites the private field 'current' in the OS enum for purposes of testing
-	 * OS-dependent outputs
-	 *
-	 * @param newCurrentOS the new current OS
-	 * @throws Exception if reflection fails
-	 */
-	public static void setCurrentOS(OS newCurrentOS) throws Exception {
-		Field currentOSField = OS.class.getField("current");
-		currentOSField.setAccessible(true);
+  /**
+   * Overwrites the private field 'current' in the OS enum for purposes of testing OS-dependent
+   * outputs
+   *
+   * @param newCurrentOS the new current OS
+   * @throws Exception if reflection fails
+   */
+  public static void setCurrentOS(OS newCurrentOS) throws Exception {
+    Field currentOSField = OS.class.getField("current");
+    currentOSField.setAccessible(true);
 
-		Field modifiersField = Field.class.getDeclaredField("modifiers");
-		modifiersField.setAccessible(true);
-		modifiersField.setInt(currentOSField, currentOSField.getModifiers() & ~Modifier.FINAL);
+    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    modifiersField.setAccessible(true);
+    modifiersField.setInt(currentOSField, currentOSField.getModifiers() & ~Modifier.FINAL);
 
-		currentOSField.set(null, newCurrentOS);
-	}
+    currentOSField.set(null, newCurrentOS);
+  }
 }

--- a/src/test/java/fxlauncher/tools/io/ClasspathResourceFetcherTest.java
+++ b/src/test/java/fxlauncher/tools/io/ClasspathResourceFetcherTest.java
@@ -1,0 +1,32 @@
+package fxlauncher.tools.io;
+
+import static fxlauncher.tools.io.InputStreamTools.readInputStream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+public class ClasspathResourceFetcherTest {
+
+	@Test
+	void fetchClasspathResource() {
+		String expected = "I've got a lovely bunch of coconuts. There they are a-standing in a row.";
+		String resourceName = "/GenericClasspathResource.txt";
+
+		Optional<InputStream> fetched = new ClasspathResourceFetcher(resourceName).fetch();
+		assertTrue(fetched.isPresent());
+		assertEquals(expected, readInputStream(fetched.get()));
+	}
+
+	@Test
+	void classpathResourceNotFound() {
+		String resourceName = "/IMadeThisOneUp.txt";
+
+		Optional<InputStream> fetched = new ClasspathResourceFetcher(resourceName).fetch();
+		assertFalse(fetched.isPresent());
+	}
+}

--- a/src/test/resources/GenericClasspathResource.txt
+++ b/src/test/resources/GenericClasspathResource.txt
@@ -1,0 +1,1 @@
+I've got a lovely bunch of coconuts. There they are a-standing in a row.

--- a/src/test/resources/invalid.launcher.properties
+++ b/src/test/resources/invalid.launcher.properties
@@ -1,0 +1,1 @@
+broken-property=\uxxxx

--- a/src/test/resources/test.launcher.properties
+++ b/src/test/resources/test.launcher.properties
@@ -1,0 +1,17 @@
+config-file=test-config-file
+overrides-url=https://test.override/url
+manifest-url=https://test.manifest/url
+manifest-file=test-manifest-file
+artifacts-repo-url=https://test.artifacts/repo/url
+cache-dir=test-cache-dir
+log-file=test-log-file
+ignore-ssl
+offline
+stop-on-update-error
+accept-downgrade
+preload-native-libs=list,of,native,libraries
+headless
+whats-new-url=https://whats.new/url
+lingering-update-screen
+downstream-prop=downstream-prop-value
+downstream-flag


### PR DESCRIPTION
## Problem Statement
the LauncherConfig class and various classes added to support it are not tested.

## Proposed Solution
Write tests for untested classes

## Steps taken
* Added placeholder LauncherMain class to provide a hook into the classpath near the root. Not necessary now, but not hurting anything either.
* Added test-utility classes for Collection generation/handling and logging configuration. Will likely remove the logging in a future PR. Collection handling is not robust, only used for tests, and mostly intended to minimize boilerplate in the tests themselves.
* Added mock properties files for ingest tests
* Added tests (and harnesses where appropriate) for:
    * `ClasspathResourceFetcher.class`
    * `DownstreamParameters.class`
    * `ConfigurationIngester.class` and subclasses:
        * `PropertiesFileIngester.class`
        * `ArgsIngester.class`
    * `LauncherConfig.class`
* related changes to above classes
* handful of changes to other tests where new patterns could be applied, or new tests changed the behavior of the tested class in some way. See commit messages for particulars.
* Changed original `Launcher.class` because the existing Javadoc wasn't adequate for Maven's plugin.